### PR TITLE
feat(player): add soft delete account endpoint

### DIFF
--- a/Controllers/PlayerController.cs
+++ b/Controllers/PlayerController.cs
@@ -22,11 +22,8 @@ public class PlayerController : ControllerBase
     [HttpPut("update")]
     public async Task<IActionResult> UpdateProfile([FromBody] UpdatePlayerProfileRequestDto request)
     {
-        var userIdValue =
-            User.FindFirstValue(ClaimTypes.NameIdentifier)
-            ?? User.FindFirstValue(JwtRegisteredClaimNames.Sub);
-
-        if (string.IsNullOrWhiteSpace(userIdValue) || !int.TryParse(userIdValue, out int playerUserId))
+        var userIdResult = ResolveAuthenticatedUserId();
+        if (userIdResult is null)
         {
             return Unauthorized(new
             {
@@ -35,6 +32,7 @@ public class PlayerController : ControllerBase
                 details = "Token inválido o sin identificador de usuario."
             });
         }
+        var playerUserId = userIdResult.Value;
 
         if (!Request.Headers.TryGetValue("If-Match", out var ifMatchHeader) || string.IsNullOrWhiteSpace(ifMatchHeader))
         {
@@ -92,5 +90,62 @@ public class PlayerController : ControllerBase
         }
 
         return Ok(result.Response);
+    }
+
+    [HttpPatch("delete")]
+    public async Task<IActionResult> DeleteAccount([FromBody] DeletePlayerAccountRequestDto? request)
+    {
+        var userIdResult = ResolveAuthenticatedUserId();
+        if (userIdResult is null)
+        {
+            return Unauthorized(new
+            {
+                code = 401,
+                message = "Unauthorized",
+                details = "Token inválido o sin identificador de usuario."
+            });
+        }
+
+        var reasonFromHeader = Request.Headers["X-Delete-Reason"].FirstOrDefault();
+        var reason = !string.IsNullOrWhiteSpace(request?.Reason) ? request!.Reason : reasonFromHeader;
+
+        var result = await _playerService.DeleteAccountAsync(userIdResult.Value, reason);
+
+        return result.Status switch
+        {
+            DeletePlayerAccountStatus.Success => Ok(result.Response),
+            DeletePlayerAccountStatus.NotFound => NotFound(new
+            {
+                code = 404,
+                message = "Not Found",
+                details = "No se encontró el jugador solicitado."
+            }),
+            DeletePlayerAccountStatus.Forbidden => StatusCode(StatusCodes.Status403Forbidden, new
+            {
+                code = 403,
+                message = "Forbidden",
+                details = "No tiene permisos para desactivar esta cuenta"
+            }),
+            _ => StatusCode(StatusCodes.Status500InternalServerError, new
+            {
+                code = 500,
+                message = "Internal Server Error",
+                details = "Unexpected error occurred"
+            })
+        };
+    }
+
+    private int? ResolveAuthenticatedUserId()
+    {
+        var userIdValue =
+            User.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? User.FindFirstValue(JwtRegisteredClaimNames.Sub);
+
+        if (string.IsNullOrWhiteSpace(userIdValue) || !int.TryParse(userIdValue, out int playerUserId))
+        {
+            return null;
+        }
+
+        return playerUserId;
     }
 }

--- a/DTOs/Requests/DeletePlayerAccountRequestDto.cs
+++ b/DTOs/Requests/DeletePlayerAccountRequestDto.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LevelUpLifeBackend.DTOs.Requests;
+
+public class DeletePlayerAccountRequestDto
+{
+    [StringLength(200)]
+    public string? Reason { get; set; }
+}

--- a/DTOs/Responses/DeletePlayerAccountResponseDto.cs
+++ b/DTOs/Responses/DeletePlayerAccountResponseDto.cs
@@ -1,0 +1,8 @@
+namespace LevelUpLifeBackend.DTOs.Responses;
+
+public class DeletePlayerAccountResponseDto
+{
+    public bool Success { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public DateTime DeactivatedAt { get; set; }
+}

--- a/Repositories/IPlayerRepository.cs
+++ b/Repositories/IPlayerRepository.cs
@@ -5,6 +5,7 @@ namespace LevelUpLifeBackend.Repositories;
 public interface IPlayerRepository
 {
     Task<PlayerUser?> GetActiveByIdWithRelationsAsync(int playerUserId);
+    Task<PlayerUser?> GetByIdWithRelationsAsync(int playerUserId);
     Task<bool> UserNameExistsForAnotherUserAsync(string userName, int excludedPlayerUserId);
     Task<UserPlayerClass?> GetClassByIdAsync(int classId);
     Task SaveChangesAsync();

--- a/Repositories/PlayerRepository.cs
+++ b/Repositories/PlayerRepository.cs
@@ -21,6 +21,14 @@ public class PlayerRepository : IPlayerRepository
             .FirstOrDefaultAsync(u => u.Id == playerUserId && u.IsActive);
     }
 
+    public async Task<PlayerUser?> GetByIdWithRelationsAsync(int playerUserId)
+    {
+        return await _context.PlayerUsers
+            .Include(u => u.Person)
+            .Include(u => u.Class)
+            .FirstOrDefaultAsync(u => u.Id == playerUserId);
+    }
+
     public async Task<bool> UserNameExistsForAnotherUserAsync(string userName, int excludedPlayerUserId)
     {
         return await _context.PlayerUsers.AnyAsync(u =>

--- a/Services/IPlayerService.cs
+++ b/Services/IPlayerService.cs
@@ -10,6 +10,8 @@ public interface IPlayerService
         string ifMatchHeader,
         UpdatePlayerProfileRequestDto request
     );
+
+    Task<DeletePlayerAccountServiceResult> DeleteAccountAsync(int playerUserId, string? reason);
 }
 
 public enum UpdatePlayerProfileStatus
@@ -27,4 +29,17 @@ public class UpdatePlayerProfileServiceResult
     public UpdatePlayerProfileResponseDto? Response { get; set; }
     public string? ETag { get; set; }
     public string? Details { get; set; }
+}
+
+public enum DeletePlayerAccountStatus
+{
+    Success,
+    NotFound,
+    Forbidden
+}
+
+public class DeletePlayerAccountServiceResult
+{
+    public DeletePlayerAccountStatus Status { get; set; }
+    public DeletePlayerAccountResponseDto? Response { get; set; }
 }

--- a/Services/PlayerService.cs
+++ b/Services/PlayerService.cs
@@ -106,6 +106,46 @@ public class PlayerService : IPlayerService
         };
     }
 
+    public async Task<DeletePlayerAccountServiceResult> DeleteAccountAsync(int playerUserId, string? reason)
+    {
+        var player = await _playerRepository.GetByIdWithRelationsAsync(playerUserId);
+        if (player is null)
+        {
+            return new DeletePlayerAccountServiceResult
+            {
+                Status = DeletePlayerAccountStatus.NotFound
+            };
+        }
+
+        // Si la cuenta ya está inactiva, rechazamos la operación.
+        if (!player.IsActive)
+        {
+            return new DeletePlayerAccountServiceResult
+            {
+                Status = DeletePlayerAccountStatus.Forbidden
+            };
+        }
+
+        player.IsActive = false;
+        if (player.Person is not null)
+        {
+            player.Person.IsActive = false;
+        }
+
+        await _playerRepository.SaveChangesAsync();
+
+        return new DeletePlayerAccountServiceResult
+        {
+            Status = DeletePlayerAccountStatus.Success,
+            Response = new DeletePlayerAccountResponseDto
+            {
+                Success = true,
+                Message = "Cuenta desactivada correctamente",
+                DeactivatedAt = DateTime.UtcNow
+            }
+        };
+    }
+
     private static PlayerProfileDto MapToProfileDto(PlayerUser player)
     {
         return new PlayerProfileDto


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

This PR implements and validates the account soft-delete flow for `PATCH /api/Player/delete` (Issue #8), including authentication/authorization behavior and expected response contracts.
It also provides a reproducible QA flow with required setup steps (`dotnet run`, login, JWT token usage) and evidence for `200`, `401`, and `403` scenarios.

---

## 🎯 Purpose

This change ensures secure and consistent account deactivation behavior:
- Deactivate an active account when a valid JWT is provided.
- Reject requests without authentication.
- Reject repeated deactivation attempts for already inactive accounts.

This is required because the endpoint is protected and must be tested end-to-end with a valid bearer token.

---

## 🔄 Type of Change

Please check the relevant option:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

Describe the tests you ran and how you verified your changes.

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

Explain the testing process:

### 1) Start backend locally (required)
1. Open a terminal in the backend project root.
2. Run: `dotnet run`
3. Confirm the API is running (example): `http://localhost:5223`.

### 2) Generate auth token (required before calling the protected endpoint)
To access `PATCH /api/Player/delete`, QA must authenticate first:
1. Call `POST /api/Auth/login` with valid credentials.
2. Copy the JWT token from the login response.
3. Use the token in subsequent requests as: `Authorization: Bearer <jwt_token>`

> Without this token, access to the delete endpoint is denied.

### 3) Test cases

**T01 — Successful account soft delete (`200 OK`)**
- Method: `PATCH`
- URL: `http://localhost:5223/api/Player/delete`
- Headers:
  - `accept: */*`
  - `content-type: application/json`
  - `authorization: Bearer <jwt_token>`
- Body: `{ "reason": "User requested deactivation" }`
- Expected response:
  - HTTP `200 OK`
  - `success: true`
  - `message: "Cuenta desactivada correctamente"`
  - `deactivatedAt` present

**T02 — Missing authentication token (`401 Unauthorized`)**
- Same endpoint and body
- Do NOT send `Authorization`
- Expected response: HTTP `401 Unauthorized`

**T03 — Repeated delete on already deactivated account (`403 Forbidden`)**
- Precondition: T01 already executed with the same user (account is now inactive)
- Same endpoint with a valid token for the same user
- Body: `{ "reason": "Retry after deactivation" }`
- Expected response:
  - HTTP `403 Forbidden`
  - `code: 403`
  - `message: "Forbidden"`
  - `details: "No tiene permisos para desactivar esta cuenta"`

---

## 📸 Screenshots (if applicable)

### Test Evidence

| Test ID | Scenario | Expected | Evidence |
|---|---|---|---|
| T01 | Successful account soft delete | `200 OK` | <img width="1403" height="856" alt="image" src="https://github.com/user-attachments/assets/4e43df7c-271f-41ea-b32f-346810c6fbbf" /> |
| T02 | Missing authentication token | `401 Unauthorized` | <img width="1386" height="849" alt="image" src="https://github.com/user-attachments/assets/5de48b65-930d-4509-858f-64bd9f57a882" /> |
| T03 | Repeated delete on already deactivated account | `403 Forbidden` | <img width="1384" height="848" alt="image" src="https://github.com/user-attachments/assets/290ffd1e-da67-40bc-b9fe-389a7e28010a" />|

---


## 🚀 Deployment Notes (if needed)

No special deployment steps are required beyond the standard backend deployment process.
For local QA verification, the backend must be running via `dotnet run`.

---

## ✅ Checklist

Before requesting a review, please confirm:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [x] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #8
Linked to #7