### PR TITLE
feat(errors): global API error handling (#46)

### DIFF
--- a/Infrastructure/Errors/ApiErrorParser.cs
+++ b/Infrastructure/Errors/ApiErrorParser.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+
+namespace LevelUpLifeBackend.Infrastructure.Errors;
+
+public sealed class ApiErrorParser : IApiErrorParser
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task<AppError> ParseApiErrorAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var status = (int)response.StatusCode;
+        var rawBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        var payload = NormalizePayload(status, response.ReasonPhrase, rawBody);
+        return MapToError(status, payload);
+    }
+
+    internal static ErrorResponse NormalizePayload(int httpStatus, string? reasonPhrase, string rawBody)
+    {
+        ErrorResponse? parsed = null;
+        if (!string.IsNullOrWhiteSpace(rawBody))
+        {
+            try
+            {
+                parsed = JsonSerializer.Deserialize<ErrorResponse>(rawBody, JsonOptions);
+            }
+            catch (JsonException)
+            {
+                // JSON inválido: se usa fallback abajo.
+            }
+        }
+
+        if (parsed is null)
+        {
+            return new ErrorResponse
+            {
+                Code = httpStatus,
+                Message = string.IsNullOrWhiteSpace(reasonPhrase)
+                    ? "Unexpected error"
+                    : reasonPhrase.Trim(),
+                Details = TruncateDetails(rawBody),
+            };
+        }
+
+        if (parsed.Code == 0)
+        {
+            parsed.Code = httpStatus;
+        }
+
+        if (string.IsNullOrWhiteSpace(parsed.Message))
+        {
+            parsed.Message = string.IsNullOrWhiteSpace(reasonPhrase)
+                ? "Unexpected error"
+                : reasonPhrase.Trim();
+        }
+
+        parsed.Details ??= string.Empty;
+        return parsed;
+    }
+
+    private static AppError MapToError(int status, ErrorResponse payload)
+    {
+        return status switch
+        {
+            401 => new AuthError(401, payload, AuthFailureKind.Unauthorized),
+            403 => new AuthError(403, payload, AuthFailureKind.Forbidden),
+            404 => new NotFoundError(payload),
+            409 => new ConflictError(payload),
+            412 => new ProfileError(payload, ProfileFailureKind.ETagMismatch),
+            >= 500 and < 600 => new ServerError(status, payload),
+            _ => new UnexpectedApiError(status, payload),
+        };
+    }
+
+    private static string TruncateDetails(string raw, int max = 8000)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return string.Empty;
+        }
+
+        raw = raw.Trim();
+        return raw.Length <= max ? raw : raw[..max];
+    }
+}

--- a/Infrastructure/Errors/AppError.cs
+++ b/Infrastructure/Errors/AppError.cs
@@ -1,0 +1,17 @@
+namespace LevelUpLifeBackend.Infrastructure.Errors;
+
+/// <summary>
+/// Error de aplicación tipado, construido a partir de una respuesta HTTP y/o <see cref="ErrorResponse"/>.
+/// </summary>
+public class AppError : Exception
+{
+    public int HttpStatusCode { get; }
+    public ErrorResponse Payload { get; }
+
+    public AppError(int httpStatusCode, ErrorResponse payload, string? message = null)
+        : base(message ?? payload.Message)
+    {
+        HttpStatusCode = httpStatusCode;
+        Payload = payload;
+    }
+}

--- a/Infrastructure/Errors/AuthError.cs
+++ b/Infrastructure/Errors/AuthError.cs
@@ -1,0 +1,26 @@
+namespace LevelUpLifeBackend.Infrastructure.Errors;
+
+public enum AuthFailureKind
+{
+    Unauthorized,
+    Forbidden,
+}
+
+/// <summary>401 o 403 mapeados a error de autenticación/autorización.</summary>
+public sealed class AuthError : AppError
+{
+    public AuthFailureKind Kind { get; }
+
+    public AuthError(int httpStatusCode, ErrorResponse payload, AuthFailureKind kind)
+        : base(httpStatusCode, payload, BuildMessage(payload, kind))
+    {
+        Kind = kind;
+    }
+
+    private static string BuildMessage(ErrorResponse payload, AuthFailureKind kind)
+    {
+        return kind == AuthFailureKind.Forbidden
+            ? $"FORBIDDEN: {payload.Message}"
+            : payload.Message;
+    }
+}

--- a/Infrastructure/Errors/ConflictError.cs
+++ b/Infrastructure/Errors/ConflictError.cs
@@ -1,0 +1,9 @@
+namespace LevelUpLifeBackend.Infrastructure.Errors;
+
+public sealed class ConflictError : AppError
+{
+    public ConflictError(ErrorResponse payload)
+        : base(409, payload)
+    {
+    }
+}

--- a/Infrastructure/Errors/ErrorResponse.cs
+++ b/Infrastructure/Errors/ErrorResponse.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace LevelUpLifeBackend.Infrastructure.Errors;
+
+/// <summary>
+/// Cuerpo de error estándar devuelto por APIs externas (issue #46).
+/// </summary>
+public sealed class ErrorResponse
+{
+    [JsonPropertyName("code")]
+    public int Code { get; set; }
+
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = string.Empty;
+
+    [JsonPropertyName("details")]
+    public string Details { get; set; } = string.Empty;
+}

--- a/Infrastructure/Errors/IApiErrorParser.cs
+++ b/Infrastructure/Errors/IApiErrorParser.cs
@@ -1,0 +1,13 @@
+namespace LevelUpLifeBackend.Infrastructure.Errors;
+
+/// <summary>
+/// Convierte una <see cref="HttpResponseMessage"/> fallida en un <see cref="AppError"/> tipado (issue #46).
+/// </summary>
+public interface IApiErrorParser
+{
+    /// <summary>Equivalente semántico a parseApiError(response) de la especificación.</summary>
+    Task<AppError> ParseApiErrorAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/Infrastructure/Errors/NotFoundError.cs
+++ b/Infrastructure/Errors/NotFoundError.cs
@@ -1,0 +1,9 @@
+namespace LevelUpLifeBackend.Infrastructure.Errors;
+
+public sealed class NotFoundError : AppError
+{
+    public NotFoundError(ErrorResponse payload)
+        : base(404, payload)
+    {
+    }
+}

--- a/Infrastructure/Errors/ProfileError.cs
+++ b/Infrastructure/Errors/ProfileError.cs
@@ -1,0 +1,18 @@
+namespace LevelUpLifeBackend.Infrastructure.Errors;
+
+public enum ProfileFailureKind
+{
+    ETagMismatch,
+}
+
+/// <summary>412 Precondition Failed u otros errores de perfil/concurrencia.</summary>
+public sealed class ProfileError : AppError
+{
+    public ProfileFailureKind Kind { get; }
+
+    public ProfileError(ErrorResponse payload, ProfileFailureKind kind = ProfileFailureKind.ETagMismatch)
+        : base(412, payload, kind == ProfileFailureKind.ETagMismatch ? $"ETAG_MISMATCH: {payload.Message}" : payload.Message)
+    {
+        Kind = kind;
+    }
+}

--- a/Infrastructure/Errors/README.md
+++ b/Infrastructure/Errors/README.md
@@ -1,0 +1,46 @@
+# Global error handling (Issue #46)
+
+## Modelo `ErrorResponse`
+
+Contrato JSON esperado en cuerpos de error de APIs externas:
+
+```json
+{
+  "code": 404,
+  "message": "string",
+  "details": "string"
+}
+```
+
+Si el cuerpo no es JSON válido o viene incompleto, `ApiErrorParser` rellena `code` con el HTTP status, `message` con `ReasonPhrase` (o un texto por defecto) y `details` con el cuerpo bruto truncado.
+
+## `parseApiError` → `IApiErrorParser.ParseApiErrorAsync`
+
+Inyectá `IApiErrorParser` cuando manejes manualmente un `HttpResponseMessage` fallido:
+
+```csharp
+if (!response.IsSuccessStatusCode)
+    throw await _parser.ParseApiErrorAsync(response, cancellationToken);
+```
+
+## Mapa HTTP → error tipado
+
+| Status | Tipo |
+|--------|------|
+| 401 | `AuthError` (`Unauthorized`) |
+| 403 | `AuthError` (`Forbidden`, mensaje con prefijo `FORBIDDEN:`) |
+| 404 | `NotFoundError` |
+| 409 | `ConflictError` |
+| 412 | `ProfileError` (`ETagMismatch`) |
+| 5xx | `ServerError` |
+| Otros | `UnexpectedApiError` |
+
+## Uso con `IBaseApiClient` (issue #45)
+
+`BaseApiClient` llama al parser en respuestas no exitosas: no se devuelven errores HTTP “crudos” al llamador; se lanza un `AppError` derivado.
+
+Los servicios de dominio que solo usan EF/repositorios no pasan por HTTP; la regla aplica a **cualquier** código que consuma APIs externas vía `IBaseApiClient` o que inspeccione `HttpResponseMessage` manualmente.
+
+## Verificación
+
+La evidencia automatizada está en el proyecto de pruebas: `dotnet test LevelUpLife-Backend.Tests/LevelUpLife-Backend.Tests.csproj`.

--- a/Infrastructure/Errors/ServerError.cs
+++ b/Infrastructure/Errors/ServerError.cs
@@ -1,0 +1,10 @@
+namespace LevelUpLifeBackend.Infrastructure.Errors;
+
+/// <summary>5xx del servidor remoto.</summary>
+public sealed class ServerError : AppError
+{
+    public ServerError(int httpStatusCode, ErrorResponse payload)
+        : base(httpStatusCode, payload)
+    {
+    }
+}

--- a/Infrastructure/Errors/UnexpectedApiError.cs
+++ b/Infrastructure/Errors/UnexpectedApiError.cs
@@ -1,0 +1,10 @@
+namespace LevelUpLifeBackend.Infrastructure.Errors;
+
+/// <summary>Error HTTP no contemplado explícitamente en el mapa de la issue #46.</summary>
+public sealed class UnexpectedApiError : AppError
+{
+    public UnexpectedApiError(int httpStatusCode, ErrorResponse payload)
+        : base(httpStatusCode, payload)
+    {
+    }
+}

--- a/Infrastructure/Http/BaseApiClient.cs
+++ b/Infrastructure/Http/BaseApiClient.cs
@@ -1,7 +1,6 @@
 using System.Net.Http.Json;
-using System.Net.Http.Headers;
-using System.Text;
 using System.Text.Json;
+using LevelUpLifeBackend.Infrastructure.Errors;
 using Microsoft.Extensions.Options;
 
 namespace LevelUpLifeBackend.Infrastructure.Http;
@@ -11,36 +10,70 @@ public sealed class BaseApiClient : IBaseApiClient
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private readonly HttpClient _httpClient;
     private readonly BaseHttpClientOptions _options;
+    private readonly IApiErrorParser _apiErrorParser;
 
-    public BaseApiClient(HttpClient httpClient, IOptions<BaseHttpClientOptions> options)
+    public BaseApiClient(
+        HttpClient httpClient,
+        IOptions<BaseHttpClientOptions> options,
+        IApiErrorParser apiErrorParser
+    )
     {
         _httpClient = httpClient;
         _options = options.Value;
+        _apiErrorParser = apiErrorParser;
     }
 
-    public Task<HttpResponseMessage> GetAsync(
+    public async Task<HttpResponseMessage> GetAsync(
         string relativePath,
         CancellationToken cancellationToken = default
-    ) => _httpClient.GetAsync(BuildPath(relativePath), cancellationToken);
+    )
+    {
+        var response = await _httpClient
+            .GetAsync(BuildPath(relativePath), cancellationToken)
+            .ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+        return response;
+    }
 
-    public Task<HttpResponseMessage> DeleteAsync(
+    public async Task<HttpResponseMessage> DeleteAsync(
         string relativePath,
         CancellationToken cancellationToken = default
-    ) => _httpClient.DeleteAsync(BuildPath(relativePath), cancellationToken);
+    )
+    {
+        var response = await _httpClient
+            .DeleteAsync(BuildPath(relativePath), cancellationToken)
+            .ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+        return response;
+    }
 
-    public Task<HttpResponseMessage> PostAsJsonAsync<TBody>(
+    public async Task<HttpResponseMessage> PostAsJsonAsync<TBody>(
         string relativePath,
         TBody body,
         CancellationToken cancellationToken = default
-    ) => _httpClient.PostAsJsonAsync(BuildPath(relativePath), body, JsonOptions, cancellationToken);
+    )
+    {
+        var response = await _httpClient
+            .PostAsJsonAsync(BuildPath(relativePath), body, JsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+        return response;
+    }
 
-    public Task<HttpResponseMessage> PutAsJsonAsync<TBody>(
+    public async Task<HttpResponseMessage> PutAsJsonAsync<TBody>(
         string relativePath,
         TBody body,
         CancellationToken cancellationToken = default
-    ) => _httpClient.PutAsJsonAsync(BuildPath(relativePath), body, JsonOptions, cancellationToken);
+    )
+    {
+        var response = await _httpClient
+            .PutAsJsonAsync(BuildPath(relativePath), body, JsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+        return response;
+    }
 
-    public Task<HttpResponseMessage> PatchAsJsonAsync<TBody>(
+    public async Task<HttpResponseMessage> PatchAsJsonAsync<TBody>(
         string relativePath,
         TBody body,
         CancellationToken cancellationToken = default
@@ -51,7 +84,19 @@ public sealed class BaseApiClient : IBaseApiClient
             Content = JsonContent.Create(body, options: JsonOptions),
         };
 
-        return _httpClient.SendAsync(request, cancellationToken);
+        var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+        return response;
+    }
+
+    private async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        throw await _apiErrorParser.ParseApiErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
     private string BuildPath(string? relativePath)
@@ -73,7 +118,6 @@ public sealed class BaseApiClient : IBaseApiClient
                 : $"{prefix}/{path}";
     }
 
-    /// <summary>Trims whitespace and leading/trailing slashes; null or whitespace becomes empty.</summary>
     private static string NormalizeSegment(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -81,7 +125,6 @@ public sealed class BaseApiClient : IBaseApiClient
             return string.Empty;
         }
 
-        var normalized = value.Trim().Trim('/');
-        return normalized;
+        return value.Trim().Trim('/');
     }
 }

--- a/Infrastructure/Http/README.md
+++ b/Infrastructure/Http/README.md
@@ -12,6 +12,7 @@ This backend now provides a single reusable outbound HTTP client via `IBaseApiCl
 - Do not create `new HttpClient()` inside services/repositories.
 - Use `IBaseApiClient` for outbound integrations.
 - Base path `/v1` is prepended automatically to every request path.
+- On non-success responses, `BaseApiClient` throws typed `AppError` via `IApiErrorParser` (see [Global error handling (Issue #46)](../Errors/README.md)).
 
 ## Interceptors
 

--- a/LevelUpLife-Backend.Tests/ApiErrorParserTests.cs
+++ b/LevelUpLife-Backend.Tests/ApiErrorParserTests.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using LevelUpLifeBackend.Infrastructure.Errors;
+using Xunit;
+
+namespace LevelUpLifeBackend.Tests;
+
+public sealed class ApiErrorParserTests
+{
+    private readonly ApiErrorParser _parser = new();
+
+    [Fact]
+    public async Task ParseApiErrorAsync_maps_error_body_code_message_details()
+    {
+        var body = JsonSerializer.Serialize(
+            new ErrorResponse
+            {
+                Code = 422,
+                Message = "Validation failed",
+                Details = "Name is required",
+            }
+        );
+
+        var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+
+        var error = await _parser.ParseApiErrorAsync(response);
+
+        var unexpected = Assert.IsType<UnexpectedApiError>(error);
+        Assert.Equal(400, unexpected.HttpStatusCode);
+        Assert.Equal(422, unexpected.Payload.Code);
+        Assert.Equal("Validation failed", unexpected.Payload.Message);
+        Assert.Equal("Name is required", unexpected.Payload.Details);
+    }
+
+    [Fact]
+    public async Task ParseApiErrorAsync_404_returns_NotFoundError()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        };
+
+        var error = await _parser.ParseApiErrorAsync(response);
+        Assert.IsType<NotFoundError>(error);
+    }
+
+    [Fact]
+    public async Task ParseApiErrorAsync_409_returns_ConflictError()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Conflict)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        };
+
+        var error = await _parser.ParseApiErrorAsync(response);
+        Assert.IsType<ConflictError>(error);
+    }
+
+    [Fact]
+    public async Task ParseApiErrorAsync_412_returns_ProfileError_with_ETAG_MISMATCH()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.PreconditionFailed)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        };
+
+        var error = await _parser.ParseApiErrorAsync(response);
+        var profile = Assert.IsType<ProfileError>(error);
+        Assert.Equal(ProfileFailureKind.ETagMismatch, profile.Kind);
+        Assert.Contains("ETAG_MISMATCH", profile.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ParseApiErrorAsync_500_returns_ServerError()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        };
+
+        var error = await _parser.ParseApiErrorAsync(response);
+        Assert.IsType<ServerError>(error);
+    }
+
+    [Fact]
+    public async Task ParseApiErrorAsync_401_returns_AuthError_unauthorized()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Unauthorized)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        };
+
+        var error = await _parser.ParseApiErrorAsync(response);
+        var auth = Assert.IsType<AuthError>(error);
+        Assert.Equal(AuthFailureKind.Unauthorized, auth.Kind);
+    }
+
+    [Fact]
+    public async Task ParseApiErrorAsync_403_returns_AuthError_forbidden()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        };
+
+        var error = await _parser.ParseApiErrorAsync(response);
+        var auth = Assert.IsType<AuthError>(error);
+        Assert.Equal(AuthFailureKind.Forbidden, auth.Kind);
+        Assert.Contains("FORBIDDEN", auth.Message, StringComparison.Ordinal);
+    }
+}

--- a/LevelUpLife-Backend.Tests/BaseApiClientIntegrationTests.cs
+++ b/LevelUpLife-Backend.Tests/BaseApiClientIntegrationTests.cs
@@ -1,0 +1,52 @@
+using System.Net;
+using System.Text;
+using LevelUpLifeBackend.Infrastructure.Errors;
+using LevelUpLifeBackend.Infrastructure.Http;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace LevelUpLifeBackend.Tests;
+
+public sealed class BaseApiClientIntegrationTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _send;
+
+        public StubHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> send)
+        {
+            _send = send;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) => _send(request, cancellationToken);
+    }
+
+    [Fact]
+    public async Task GetAsync_on_404_throws_NotFoundError_via_parser()
+    {
+        var handler = new StubHandler(
+            (_, _) =>
+                Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.NotFound)
+                    {
+                        Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+                    }
+                )
+        );
+
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.test/") };
+        var options = Options.Create(
+            new BaseHttpClientOptions
+            {
+                BaseUrl = "https://example.test/",
+                ApiPrefix = string.Empty,
+            }
+        );
+        var sut = new BaseApiClient(httpClient, options, new ApiErrorParser());
+
+        await Assert.ThrowsAsync<NotFoundError>(() => sut.GetAsync("resource"));
+    }
+}

--- a/LevelUpLife-Backend.Tests/LevelUpLife-Backend.Tests.csproj
+++ b/LevelUpLife-Backend.Tests/LevelUpLife-Backend.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>LevelUpLifeBackend.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LevelUpLife-Backend.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/LevelUpLife-Backend.csproj
+++ b/LevelUpLife-Backend.csproj
@@ -8,6 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Proyecto de pruebas vive en subcarpeta; no debe compilarse como parte del host web. -->
+    <Compile Remove="LevelUpLife-Backend.Tests/**/*.cs" />
+    <None Include="LevelUpLife-Backend.Tests/**/*" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.14" />

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using LevelUpLifeBackend.Data;
+using LevelUpLifeBackend.Infrastructure.Errors;
 using LevelUpLifeBackend.Infrastructure.Http;
 using LevelUpLifeBackend.Infrastructure.Http.Context;
 using LevelUpLifeBackend.Infrastructure.Http.Events;
@@ -44,6 +45,7 @@ builder.Services.AddScoped<IPlayerService, PlayerService>();
 builder.Services.Configure<BaseHttpClientOptions>(
     builder.Configuration.GetSection(BaseHttpClientOptions.SectionName)
 );
+builder.Services.AddSingleton<IApiErrorParser, ApiErrorParser>();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddSingleton<IGlobalErrorPublisher, GlobalErrorPublisher>();
 builder.Services.AddScoped<IRequestCredentialAccessor, HttpContextCredentialAccessor>();


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

Implements **issue #46 (Global Error Handling)** for outbound HTTP from this backend:

- `ErrorResponse` model (`code`, `message`, `details`) matching the issue contract.
- `IApiErrorParser` / `ApiErrorParser` with `ParseApiErrorAsync` (semantic equivalent to `parseApiError`): reads JSON body, fills missing fields, maps **HTTP status** to typed errors.
- `AppError` hierarchy: `AuthError` (401 / 403 with `Unauthorized` vs `Forbidden`), `NotFoundError`, `ConflictError`, `ProfileError` (`ETagMismatch` on 412), `ServerError` (5xx), `UnexpectedApiError` (other statuses).
- `BaseApiClient` integrates the parser: **non-success** responses throw a typed `AppError` (callers do not receive raw failed `HttpResponseMessage`).
- **`LevelUpLife-Backend.Tests`** (xUnit): acceptance-style tests for parsing/mapping plus a minimal `BaseApiClient` integration test with a stub handler.
- Docs under `Infrastructure/Errors/README.md` and a link from `Infrastructure/Http/README.md`.
- `LevelUpLife-Backend.csproj` excludes the test project folder from the web host compile (SDK Web would otherwise compile test `.cs` files).

---

## 🎯 Purpose

Standardize how this backend handles errors from **external HTTP APIs**: one error payload shape, one parser, typed exceptions—aligned with issue #46 and avoiding raw HTTP failures leaking to callers.

---

## 🔄 Type of Change

Please check the relevant option:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [x] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

- [ ] Manual testing
- [x] Unit tests
- [x] Integration tests

Explain the testing process:

1. `dotnet build LevelUpLife-Backend.csproj`
2. `dotnet test LevelUpLife-Backend.Tests/LevelUpLife-Backend.Tests.csproj` — **8 tests** (JSON `ErrorResponse` mapping, status mapping for 401/403/404/409/412/500, and `BaseApiClient` with a fake `HttpMessageHandler` returning 404).

**QA note:** this work affects **outbound** calls via `IBaseApiClient`. There are **no new public API routes** to exercise in Scalar for the parser itself. Recommended verification is running the **test suite** locally or in CI with the command above.

---

## 📸 Screenshots (if applicable)

N/A — validation is automated (`dotnet test` output).

---

## 🚀 Deployment Notes (if needed)

No special deployment steps.  
Optional: add a CI step `dotnet test LevelUpLife-Backend.Tests/LevelUpLife-Backend.Tests.csproj`.

---

## ✅ Checklist

Before requesting a review, please confirm:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [x] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #46  
Linked to #46
