### PR TITLE
Add GET /api/habit/disciplines/{id} for habit discipline detail

### DIFF
--- a/Controllers/HabitDisciplineApiController.cs
+++ b/Controllers/HabitDisciplineApiController.cs
@@ -1,0 +1,47 @@
+using LevelUpLifeBackend.Infrastructure.Errors;
+using LevelUpLifeBackend.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LevelUpLifeBackend.Controllers;
+
+[ApiController]
+[Route("api/habit/disciplines")]
+public class HabitDisciplineApiController : ControllerBase
+{
+    private readonly IHabitDisciplineService _habitDisciplineService;
+
+    public HabitDisciplineApiController(IHabitDisciplineService habitDisciplineService)
+    {
+        _habitDisciplineService = habitDisciplineService;
+    }
+
+    [HttpGet("{id:int}")]
+    public async Task<IActionResult> GetById(int id)
+    {
+        try
+        {
+            var discipline = await _habitDisciplineService.GetDisciplineByIdAsync(id);
+            return Ok(discipline);
+        }
+        catch (NotFoundError ex)
+        {
+            return NotFound(ex.Payload);
+        }
+        catch (ServerError ex)
+        {
+            return StatusCode(ex.HttpStatusCode, ex.Payload);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(
+                500,
+                new ErrorResponse
+                {
+                    Code = 500,
+                    Message = "An unexpected error occurred.",
+                    Details = ex.Message,
+                }
+            );
+        }
+    }
+}

--- a/DTOs/Responses/HabitDisciplineDetailResponseDto.cs
+++ b/DTOs/Responses/HabitDisciplineDetailResponseDto.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace LevelUpLifeBackend.DTOs.Responses;
+
+public sealed class HabitDisciplineDetailResponseDto
+{
+    [JsonPropertyName("idHabitDiscipline")]
+    public int IdHabitDiscipline { get; set; }
+
+    [JsonPropertyName("idHabitCategory")]
+    public int IdHabitCategory { get; set; }
+
+    [JsonPropertyName("dscHabitDisciplineName")]
+    public string DscHabitDisciplineName { get; set; } = string.Empty;
+
+    [JsonPropertyName("dscHabitDisciplineDescription")]
+    public string DscHabitDisciplineDescription { get; set; } = string.Empty;
+
+    [JsonPropertyName("statusHabitDisciplineIsActive")]
+    public bool StatusHabitDisciplineIsActive { get; set; }
+}

--- a/LevelUpLife-Backend.Tests/HabitDisciplineServiceTests.cs
+++ b/LevelUpLife-Backend.Tests/HabitDisciplineServiceTests.cs
@@ -1,0 +1,65 @@
+using LevelUpLifeBackend.Infrastructure.Errors;
+using LevelUpLifeBackend.Models;
+using LevelUpLifeBackend.Repositories;
+using LevelUpLifeBackend.Services;
+using Moq;
+using Xunit;
+
+namespace LevelUpLife_Backend.Tests;
+
+public class HabitDisciplineServiceTests
+{
+    private readonly Mock<IHabitDisciplineRepository> _repositoryMock;
+    private readonly HabitDisciplineService _service;
+
+    public HabitDisciplineServiceTests()
+    {
+        _repositoryMock = new Mock<IHabitDisciplineRepository>();
+        _service = new HabitDisciplineService(_repositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task GetDisciplineByIdAsync_WhenDisciplineExists_ReturnsDto()
+    {
+        var discipline = new HabitDiscipline
+        {
+            Id = 7,
+            Name = "Strength",
+            Description = "Physical training",
+            IsActive = true,
+            Category = new HabitCategory { Id = 3 },
+        };
+
+        _repositoryMock.Setup(r => r.GetByIdAsync(7)).ReturnsAsync(discipline);
+
+        var result = await _service.GetDisciplineByIdAsync(7);
+
+        Assert.NotNull(result);
+        Assert.Equal(7, result.IdHabitDiscipline);
+        Assert.Equal(3, result.IdHabitCategory);
+        Assert.Equal("Strength", result.DscHabitDisciplineName);
+        Assert.Equal("Physical training", result.DscHabitDisciplineDescription);
+        Assert.True(result.StatusHabitDisciplineIsActive);
+    }
+
+    [Fact]
+    public async Task GetDisciplineByIdAsync_WhenDisciplineDoesNotExist_ThrowsNotFoundError()
+    {
+        _repositoryMock.Setup(r => r.GetByIdAsync(999)).ReturnsAsync((HabitDiscipline?)null);
+
+        var exception = await Assert.ThrowsAsync<NotFoundError>(() => _service.GetDisciplineByIdAsync(999));
+
+        Assert.Equal(404, exception.HttpStatusCode);
+        Assert.Equal(404, exception.Payload.Code);
+    }
+
+    [Fact]
+    public async Task GetDisciplineByIdAsync_WhenRepositoryThrowsException_ThrowsServerError()
+    {
+        _repositoryMock.Setup(r => r.GetByIdAsync(1)).ThrowsAsync(new Exception("Database error"));
+
+        var exception = await Assert.ThrowsAsync<ServerError>(() => _service.GetDisciplineByIdAsync(1));
+
+        Assert.Equal(500, exception.HttpStatusCode);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -70,6 +70,9 @@ builder.Services.AddScoped<IRepetitionCriteriaRepository, RepetitionCriteriaRepo
 builder.Services.AddScoped<IHabitCategoryRepository, HabitCategoryRepository>();
 builder.Services.AddScoped<IHabitCategoryService, HabitCategoryService>();
 
+builder.Services.AddScoped<IHabitDisciplineRepository, HabitDisciplineRepository>();
+builder.Services.AddScoped<IHabitDisciplineService, HabitDisciplineService>();
+
 // Repositorios y Servicios de Autenticación
 builder.Services.AddScoped<IAuthRepository, AuthRepository>();
 builder.Services.AddScoped<IAuthService, AuthService>();

--- a/Repositories/HabitDisciplineRepository.cs
+++ b/Repositories/HabitDisciplineRepository.cs
@@ -1,0 +1,23 @@
+using LevelUpLifeBackend.Data;
+using LevelUpLifeBackend.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace LevelUpLifeBackend.Repositories;
+
+public class HabitDisciplineRepository : IHabitDisciplineRepository
+{
+    private readonly AppDbContext _context;
+
+    public HabitDisciplineRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<HabitDiscipline?> GetByIdAsync(int id)
+    {
+        return await _context.Disciplines
+            .AsNoTracking()
+            .Include(d => d.Category)
+            .FirstOrDefaultAsync(d => d.Id == id);
+    }
+}

--- a/Repositories/IHabitDisciplineRepository.cs
+++ b/Repositories/IHabitDisciplineRepository.cs
@@ -1,0 +1,8 @@
+using LevelUpLifeBackend.Models;
+
+namespace LevelUpLifeBackend.Repositories;
+
+public interface IHabitDisciplineRepository
+{
+    Task<HabitDiscipline?> GetByIdAsync(int id);
+}

--- a/Services/HabitDisciplineService.cs
+++ b/Services/HabitDisciplineService.cs
@@ -1,0 +1,60 @@
+using LevelUpLifeBackend.DTOs.Responses;
+using LevelUpLifeBackend.Infrastructure.Errors;
+using LevelUpLifeBackend.Repositories;
+
+namespace LevelUpLifeBackend.Services;
+
+public class HabitDisciplineService : IHabitDisciplineService
+{
+    private readonly IHabitDisciplineRepository _habitDisciplineRepository;
+
+    public HabitDisciplineService(IHabitDisciplineRepository habitDisciplineRepository)
+    {
+        _habitDisciplineRepository = habitDisciplineRepository;
+    }
+
+    public async Task<HabitDisciplineDetailResponseDto> GetDisciplineByIdAsync(int id)
+    {
+        try
+        {
+            var discipline = await _habitDisciplineRepository.GetByIdAsync(id);
+
+            if (discipline is null)
+            {
+                throw new NotFoundError(
+                    new ErrorResponse
+                    {
+                        Code = 404,
+                        Message = $"Discipline with ID {id} not found.",
+                        Details = "The requested habit discipline does not exist in the database.",
+                    }
+                );
+            }
+
+            return new HabitDisciplineDetailResponseDto
+            {
+                IdHabitDiscipline = discipline.Id,
+                IdHabitCategory = discipline.Category.Id,
+                DscHabitDisciplineName = discipline.Name,
+                DscHabitDisciplineDescription = discipline.Description,
+                StatusHabitDisciplineIsActive = discipline.IsActive,
+            };
+        }
+        catch (NotFoundError)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new ServerError(
+                500,
+                new ErrorResponse
+                {
+                    Code = 500,
+                    Message = "An unexpected error occurred while fetching the habit discipline.",
+                    Details = ex.Message,
+                }
+            );
+        }
+    }
+}

--- a/Services/IHabitDisciplineService.cs
+++ b/Services/IHabitDisciplineService.cs
@@ -1,0 +1,8 @@
+using LevelUpLifeBackend.DTOs.Responses;
+
+namespace LevelUpLifeBackend.Services;
+
+public interface IHabitDisciplineService
+{
+    Task<HabitDisciplineDetailResponseDto> GetDisciplineByIdAsync(int id);
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

Adds a read endpoint that returns a single habit discipline by primary key. The JSON shape matches the agreed API contract (`idHabitDiscipline`, `idHabitCategory`, `dscHabitDisciplineName`, `dscHabitDisciplineDescription`, `statusHabitDisciplineIsActive`). Missing disciplines return HTTP 404 with the standard `ErrorResponse` body (`code`, `message`, `details`), consistent with `HabitTaskController` / `NotFoundError`.

Implementation includes `IHabitDisciplineRepository` / `HabitDisciplineRepository`, `IHabitDisciplineService` / `HabitDisciplineService`, response DTO with `[JsonPropertyName]`, DI registration in `Program.cs`, and unit tests for success, not-found, and repository failure paths.

---

## 🎯 Purpose

**Problem:** Clients need to resolve discipline metadata by id without pulling full habit payloads.

**Why:** Supports discipline detail screens and validation flows; aligns backend with the feature contract for “Get Discipline Detail.”

---

## 🔄 Type of Change

Please check the relevant option:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

Describe the tests you ran and how you verified your changes.

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests

Explain the testing process:

- **Unit:** `LevelUpLife-Backend.Tests/HabitDisciplineServiceTests.cs` — discipline found maps to DTO; missing id throws `NotFoundError`; repository exception surfaces as `ServerError`.
- **Manual:** Ran API locally and verified 200 vs 404 with `curl` after ensuring at least one row exists in `LULM_HABIT_DISCIPLINE` (see SQL/curl below).

---

## 📸 Screenshots (if applicable)

Add screenshots or screen recordings to help explain your changes.

_N/A — API-only change._

---

## 🚀 Deployment Notes (if needed)

Are there any special steps required for deployment?

- No migrations or config keys added. Ensure PostgreSQL matches existing schema (`LULM_HABIT_DISCIPLINE`, `LULM_HABIT_CATEGORY`). No extra deployment steps.

---

## ✅ Checklist

Before requesting a review, please confirm:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #20  
Linked to #

---

## 🔗 Endpoint

| Method | Path |
|--------|------|
| GET | `/api/habit/disciplines/{id}` |

---

## 🗄️ Reference SQL (local test data)

**Full chain** when category, discipline, and habit must be created together (empty catalog tables):

```sql
WITH cat AS (
  INSERT INTO "LULM_HABIT_CATEGORY" (
    "DSC_HABIT_CATEGORY_NAME",
    "DSC_HABIT_CATEGORY_DESCRIPTION",
    "STATUS_HABIT_CATEGORY_IS_ACTIVE"
  )
  VALUES ('Health', 'Test category', true)
  RETURNING "ID_HABIT_CATEGORY"
),
disc AS (
  INSERT INTO "LULM_HABIT_DISCIPLINE" (
    "ID_HABIT_CATEGORY",
    "DSC_HABIT_DISCIPLINE_NAME",
    "DSC_HABIT_DISCIPLINE_DESCRIPTION",
    "STATUS_HABIT_DISCIPLINE_IS_ACTIVE"
  )
  SELECT
    cat."ID_HABIT_CATEGORY",
    'Exercise',
    'Test discipline',
    true
  FROM cat
  RETURNING "ID_HABIT_DISCIPLINE"
)
INSERT INTO "LULM_HABIT" (
  "ID_HABIT_DISCIPLINE",
  "ID_PLAYER_USER",
  "DSC_HABIT_TITLE",
  "DSC_HABIT_DESCRIPTION",
  "STATUS_HABIT_IS_ACTIVE"
)
SELECT
  disc."ID_HABIT_DISCIPLINE",
  2,
  'Test habit F3N1X',
  'Manual insert from psql',
  true
FROM disc;
```

**If categories already exist:** insert a discipline with a valid `ID_HABIT_CATEGORY` (example using category `2`):

```sql
INSERT INTO "LULM_HABIT_DISCIPLINE" (
  "ID_HABIT_CATEGORY",
  "DSC_HABIT_DISCIPLINE_NAME",
  "DSC_HABIT_DISCIPLINE_DESCRIPTION",
  "STATUS_HABIT_DISCIPLINE_IS_ACTIVE"
)
VALUES (2, 'Exercise', 'Test discipline', true)
RETURNING "ID_HABIT_DISCIPLINE";
```

Use the returned or queried `ID_HABIT_DISCIPLINE` in the success `curl` below — **do not assume** it is `1`.

---

## 🖥️ `curl` commands (manual)

Replace `N` with an `ID_HABIT_DISCIPLINE` that exists in your database.

**200 — discipline found**

```bash
curl -sS -D - "http://localhost:5223/api/habit/disciplines/N" -H "Accept: application/json"
```

**404 — discipline not found**

```bash
curl -sS -D - "http://localhost:5223/api/habit/disciplines/999999" -H "Accept: application/json"
```

Example 404 response body:

```json
{"code":404,"message":"Discipline with ID 999999 not found.","details":"The requested habit discipline does not exist in the database."}
```

---

## 📎 Create / update the PR from the terminal

```bash
gh pr create --base dev --head feature-20_Get_Habit_Discipline_Detail --title "feat: GET habit discipline detail by id" --body-file PR_BODY.md
```

## Evidence
 
### 200 Ok get habits details
<img width="668" height="305" alt="image" src="https://github.com/user-attachments/assets/b5c4776c-e8ed-44c7-9f2f-0baf8cbf3187" />

### 404
<img width="668" height="305" alt="image" src="https://github.com/user-attachments/assets/58747b0f-911d-4de8-9492-6812d821a4a3" />

