### PR TITLE
Add repetition-criteria deactivation endpoint

### DIFF
--- a/Controllers/HabitTaskController.cs
+++ b/Controllers/HabitTaskController.cs
@@ -9,10 +9,12 @@ namespace LevelUpLifeBackend.Controllers;
 public class HabitTaskController : ControllerBase
 {
     private readonly IHabitTaskService _habitTaskService;
+    private readonly IRepetitionCriteriaService _repetitionCriteriaService;
 
-    public HabitTaskController(IHabitTaskService habitTaskService)
+    public HabitTaskController(IHabitTaskService habitTaskService, IRepetitionCriteriaService repetitionCriteriaService)
     {
         _habitTaskService = habitTaskService;
+        _repetitionCriteriaService = repetitionCriteriaService;
     }
 
     [HttpGet("{taskId:int}/evidences")]
@@ -22,6 +24,33 @@ public class HabitTaskController : ControllerBase
         {
             var evidences = await _habitTaskService.GetEvidencesByTaskIdAsync(taskId);
             return Ok(evidences);
+        }
+        catch (NotFoundError ex)
+        {
+            return NotFound(ex.Payload);
+        }
+        catch (ServerError ex)
+        {
+            return StatusCode(ex.HttpStatusCode, ex.Payload);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new ErrorResponse
+            {
+                Code = 500,
+                Message = "An unexpected error occurred.",
+                Details = ex.Message
+            });
+        }
+    }
+
+    [HttpDelete("{taskId:int}/repetition-criteria/{id:int}")]
+    public async Task<IActionResult> DeactivateRepetitionCriteria(int taskId, int id)
+    {
+        try
+        {
+            await _repetitionCriteriaService.DeactivateAsync(taskId, id);
+            return Ok(new { message = "Repetition criteria deactivated successfully." });
         }
         catch (NotFoundError ex)
         {

--- a/Program.cs
+++ b/Program.cs
@@ -66,6 +66,7 @@ builder.Services.AddScoped<IHabitService, HabitService>();
 builder.Services.AddScoped<IHabitTaskRepository, HabitTaskRepository>();
 builder.Services.AddScoped<IHabitTaskService, HabitTaskService>();
 builder.Services.AddScoped<IRepetitionCriteriaRepository, RepetitionCriteriaRepository>();
+builder.Services.AddScoped<IRepetitionCriteriaService, RepetitionCriteriaService>();
 // Services and Repositories of Habit Category
 builder.Services.AddScoped<IHabitCategoryRepository, HabitCategoryRepository>();
 builder.Services.AddScoped<IHabitCategoryService, HabitCategoryService>();

--- a/Services/IRepetitionCriteriaService.cs
+++ b/Services/IRepetitionCriteriaService.cs
@@ -1,0 +1,6 @@
+namespace LevelUpLifeBackend.Services;
+
+public interface IRepetitionCriteriaService
+{
+    Task DeactivateAsync(int taskId, int id);
+}

--- a/Services/RepetitionCriteriaService.cs
+++ b/Services/RepetitionCriteriaService.cs
@@ -1,0 +1,48 @@
+using LevelUpLifeBackend.Infrastructure.Errors;
+using LevelUpLifeBackend.Repositories;
+
+namespace LevelUpLifeBackend.Services;
+
+public class RepetitionCriteriaService : IRepetitionCriteriaService
+{
+    private readonly IRepetitionCriteriaRepository _repetitionCriteriaRepository;
+
+    public RepetitionCriteriaService(IRepetitionCriteriaRepository repetitionCriteriaRepository)
+    {
+        _repetitionCriteriaRepository = repetitionCriteriaRepository;
+    }
+
+    public async Task DeactivateAsync(int taskId, int id)
+    {
+        try
+        {
+            var criteria = await _repetitionCriteriaRepository.GetByTaskIdAsync(taskId);
+
+            if (criteria == null || criteria.Id != id)
+            {
+                throw new NotFoundError(new ErrorResponse
+                {
+                    Code = 404,
+                    Message = $"Repetition criteria with ID {id} not found for task {taskId}.",
+                    Details = "The requested repetition criteria does not exist or does not belong to the specified task."
+                });
+            }
+
+            criteria.StatusRepetitionsCriteriaIsActive = false;
+            await _repetitionCriteriaRepository.UpdateAsync(criteria);
+        }
+        catch (NotFoundError)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new ServerError(500, new ErrorResponse
+            {
+                Code = 500,
+                Message = "An unexpected error occurred while deactivating repetition criteria.",
+                Details = ex.Message
+            });
+        }
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

Implements the logical delete (soft delete) for a repetition criteria record.
The endpoint marks the record as inactive by setting `StatusRepetitionsCriteriaIsActive = false`
instead of physically removing it from the database.

**Endpoint:** `DELETE /api/habit-tasks/{taskId}/repetition-criteria/{id}`

**Files added:**
- `Services/IRepetitionCriteriaService.cs`
- `Services/RepetitionCriteriaService.cs`

**Files modified:**
- `Controllers/HabitTaskController.cs` — new DELETE endpoint + `IRepetitionCriteriaService` injection
- `Program.cs` — DI registration of `RepetitionCriteriaService`

---

## 🎯 Purpose

Allows clients to deactivate a repetition criteria record tied to a specific habit task
without permanently deleting the data, preserving historical integrity.

---

## 🔄 Type of Change

- [x] ✨ New feature

---

## 🧪 How Has This Been Tested?

- [x] Manual testing

Manual tests against the local PostgreSQL Docker container (`leveluplife-db`):

| Scenario | Request | Expected | Result |
|---|---|---|---|
| Criteria deactivated | `DELETE /api/habit-tasks/2/repetition-criteria/2` | 200 + message | ✅ |
| Task not found | `DELETE /api/habit-tasks/999/repetition-criteria/1` | 404 NotFoundError | ✅ |
| ID doesn't belong to taskId | `DELETE /api/habit-tasks/1/repetition-criteria/2` | 404 NotFoundError | ✅ |

---

## 📸 Screenshots (if applicable)
<img width="1406" height="831" alt="image" src="https://github.com/user-attachments/assets/77243ff7-09b1-4cf0-85b0-18a00c6f2e2c" />

<img width="1396" height="844" alt="image" src="https://github.com/user-attachments/assets/6154713d-af00-4338-b25f-449aaf406851" />

---

## 🚀 Deployment Notes (if needed)

No migrations required. The `STATUS_REPETITIONS_CRITERIA_IS_ACTIVE` column already exists
in `LULT_HABIT_TASK_REPETITIONS_CRITERIA`.

---

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors



