### PR TITLE
Add reward item models, repository, service, API

### DIFF
--- a/Controllers/RewardItemController.cs
+++ b/Controllers/RewardItemController.cs
@@ -1,0 +1,41 @@
+using LevelUpLifeBackend.DTOs.Requests;
+using LevelUpLifeBackend.Infrastructure.Errors;
+using LevelUpLifeBackend.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LevelUpLifeBackend.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class RewardItemController : ControllerBase
+{
+    private readonly IRewardItemService _rewardItemService;
+
+    public RewardItemController(IRewardItemService rewardItemService)
+    {
+        _rewardItemService = rewardItemService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetRewardItems([FromBody] RewardItemFilterRequestDto? filter = null)
+    {
+        try
+        {
+            var items = await _rewardItemService.GetFilteredAsync(filter);
+            return Ok(items);
+        }
+        catch (ServerError ex)
+        {
+            return StatusCode(ex.HttpStatusCode, ex.Payload);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new ErrorResponse
+            {
+                Code = 500,
+                Message = "An unexpected error occurred.",
+                Details = ex.Message
+            });
+        }
+    }
+}

--- a/DTOs/Requests/RewardItemFilterRequestDto.cs
+++ b/DTOs/Requests/RewardItemFilterRequestDto.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace LevelUpLifeBackend.DTOs.Requests;
+
+public class RewardItemFilterRequestDto
+{
+    [JsonPropertyName("ID_REWARD_ITEM_TYPE")]
+    public int? TypeId { get; set; }
+
+    [JsonPropertyName("DSC_REWARD_ITEM_NAME")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("DSC_REWARD_ITEM_DESCRIPTION")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("NUM_REWARD_ITEM_COST_GOLD")]
+    public int? CostGold { get; set; }
+
+    [JsonPropertyName("NUM_REWARD_ITEM_EFFECT_VALUE")]
+    public double? EffectValue { get; set; }
+}

--- a/DTOs/Responses/RewardItemResponseDto.cs
+++ b/DTOs/Responses/RewardItemResponseDto.cs
@@ -1,0 +1,13 @@
+namespace LevelUpLifeBackend.DTOs.Responses;
+
+public class RewardItemResponseDto
+{
+    public int Id { get; set; }
+    public int TypeId { get; set; }
+    public string TypeName { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public int CostGold { get; set; }
+    public decimal? EffectValue { get; set; }
+    public bool IsActive { get; set; }
+}

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -22,6 +22,9 @@ public class AppDbContext : DbContext
     public DbSet<RepetitionCriteria> RepetitionCriteriaRecords { get; set; }
     public DbSet<EvidenceStorage> EvidenceStorages { get; set; }
 
+    public DbSet<RewardItemType> RewardItemTypes { get; set; }
+    public DbSet<RewardItem> RewardItems { get; set; }
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -208,6 +211,34 @@ public class AppDbContext : DbContext
             entity.Property(e => e.EvidencePathUrl).HasColumnName("DSC_EVIDENCE_PATH_URL");
             entity.Property(e => e.HealthDataJson).HasColumnName("DSC_HEALTH_DATA_JSON");
             entity.Property(e => e.UploadedAt).HasColumnName("FEC_UPLOADED");
+        });
+
+        modelBuilder.Entity<RewardItemType>(entity =>
+        {
+            entity.ToTable("LULM_REWARD_ITEM_TYPE");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasColumnName("ID_REWARD_ITEM_TYPE");
+            entity.Property(e => e.Name).HasColumnName("DSC_REWARD_ITEM_TYPE_NAME").HasMaxLength(100).IsRequired();
+            entity.Property(e => e.Description).HasColumnName("DSC_REWARD_ITEM_TYPE_DESC");
+            entity.Property(e => e.IsActive).HasColumnName("STATUS_REWARD_ITEM_TYPE_IS_ACTIVE");
+        });
+
+        modelBuilder.Entity<RewardItem>(entity =>
+        {
+            entity.ToTable("LULM_REWARD_ITEM");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasColumnName("ID_REWARD_ITEM");
+
+            entity.Property(e => e.TypeId).HasColumnName("ID_REWARD_ITEM_TYPE");
+            entity.HasOne(e => e.Type)
+                  .WithMany()
+                  .HasForeignKey(e => e.TypeId);
+
+            entity.Property(e => e.Name).HasColumnName("DSC_REWARD_ITEM_NAME").HasMaxLength(100).IsRequired();
+            entity.Property(e => e.Description).HasColumnName("DSC_REWARD_ITEM_DESCRIPTION");
+            entity.Property(e => e.CostGold).HasColumnName("NUM_REWARD_ITEM_COST_GOLD");
+            entity.Property(e => e.EffectValue).HasColumnName("NUM_REWARD_ITEM_EFFECT_VALUE");
+            entity.Property(e => e.IsActive).HasColumnName("STATUS_REWARD_ITEM_IS_ACTIVE");
         });
     }
 }

--- a/Models/RewardItem.cs
+++ b/Models/RewardItem.cs
@@ -1,0 +1,13 @@
+namespace LevelUpLifeBackend.Models;
+
+public class RewardItem
+{
+    public int Id { get; set; }
+    public int TypeId { get; set; }
+    public RewardItemType? Type { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public int CostGold { get; set; }
+    public decimal? EffectValue { get; set; }
+    public bool IsActive { get; set; }
+}

--- a/Models/RewardItemType.cs
+++ b/Models/RewardItemType.cs
@@ -1,0 +1,9 @@
+namespace LevelUpLifeBackend.Models;
+
+public class RewardItemType
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public bool IsActive { get; set; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -66,6 +66,10 @@ builder.Services.AddScoped<IHabitService, HabitService>();
 builder.Services.AddScoped<IHabitTaskRepository, HabitTaskRepository>();
 builder.Services.AddScoped<IHabitTaskService, HabitTaskService>();
 builder.Services.AddScoped<IRepetitionCriteriaRepository, RepetitionCriteriaRepository>();
+
+builder.Services.AddScoped<IRewardItemRepository, RewardItemRepository>();
+builder.Services.AddScoped<IRewardItemService, RewardItemService>();
+
 // Services and Repositories of Habit Category
 builder.Services.AddScoped<IHabitCategoryRepository, HabitCategoryRepository>();
 builder.Services.AddScoped<IHabitCategoryService, HabitCategoryService>();

--- a/Repositories/IRewardItemRepository.cs
+++ b/Repositories/IRewardItemRepository.cs
@@ -1,0 +1,9 @@
+using LevelUpLifeBackend.DTOs.Requests;
+using LevelUpLifeBackend.Models;
+
+namespace LevelUpLifeBackend.Repositories;
+
+public interface IRewardItemRepository
+{
+    Task<IEnumerable<RewardItem>> GetFilteredAsync(RewardItemFilterRequestDto? filter);
+}

--- a/Repositories/RewardItemRepository.cs
+++ b/Repositories/RewardItemRepository.cs
@@ -1,0 +1,44 @@
+using LevelUpLifeBackend.Data;
+using LevelUpLifeBackend.DTOs.Requests;
+using LevelUpLifeBackend.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace LevelUpLifeBackend.Repositories;
+
+public class RewardItemRepository : IRewardItemRepository
+{
+    private readonly AppDbContext _context;
+
+    public RewardItemRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IEnumerable<RewardItem>> GetFilteredAsync(RewardItemFilterRequestDto? filter)
+    {
+        var query = _context.RewardItems
+            .AsNoTracking()
+            .Include(ri => ri.Type)
+            .Where(ri => ri.IsActive);
+
+        if (filter != null)
+        {
+            if (filter.TypeId.HasValue)
+                query = query.Where(ri => ri.TypeId == filter.TypeId.Value);
+
+            if (!string.IsNullOrWhiteSpace(filter.Name))
+                query = query.Where(ri => ri.Name.Contains(filter.Name));
+
+            if (!string.IsNullOrWhiteSpace(filter.Description))
+                query = query.Where(ri => ri.Description != null && ri.Description.Contains(filter.Description));
+
+            if (filter.CostGold.HasValue)
+                query = query.Where(ri => ri.CostGold == filter.CostGold.Value);
+
+            if (filter.EffectValue.HasValue)
+                query = query.Where(ri => ri.EffectValue == (decimal)filter.EffectValue.Value);
+        }
+
+        return await query.ToListAsync();
+    }
+}

--- a/Services/IRewardItemService.cs
+++ b/Services/IRewardItemService.cs
@@ -1,0 +1,9 @@
+using LevelUpLifeBackend.DTOs.Requests;
+using LevelUpLifeBackend.DTOs.Responses;
+
+namespace LevelUpLifeBackend.Services;
+
+public interface IRewardItemService
+{
+    Task<IEnumerable<RewardItemResponseDto>> GetFilteredAsync(RewardItemFilterRequestDto? filter);
+}

--- a/Services/RewardItemService.cs
+++ b/Services/RewardItemService.cs
@@ -1,0 +1,45 @@
+using LevelUpLifeBackend.DTOs.Requests;
+using LevelUpLifeBackend.DTOs.Responses;
+using LevelUpLifeBackend.Infrastructure.Errors;
+using LevelUpLifeBackend.Repositories;
+
+namespace LevelUpLifeBackend.Services;
+
+public class RewardItemService : IRewardItemService
+{
+    private readonly IRewardItemRepository _rewardItemRepository;
+
+    public RewardItemService(IRewardItemRepository rewardItemRepository)
+    {
+        _rewardItemRepository = rewardItemRepository;
+    }
+
+    public async Task<IEnumerable<RewardItemResponseDto>> GetFilteredAsync(RewardItemFilterRequestDto? filter)
+    {
+        try
+        {
+            var items = await _rewardItemRepository.GetFilteredAsync(filter);
+
+            return items.Select(ri => new RewardItemResponseDto
+            {
+                Id = ri.Id,
+                TypeId = ri.TypeId,
+                TypeName = ri.Type?.Name ?? string.Empty,
+                Name = ri.Name,
+                Description = ri.Description,
+                CostGold = ri.CostGold,
+                EffectValue = ri.EffectValue,
+                IsActive = ri.IsActive,
+            });
+        }
+        catch (Exception ex)
+        {
+            throw new ServerError(500, new ErrorResponse
+            {
+                Code = 500,
+                Message = "An unexpected error occurred while fetching reward items.",
+                Details = ex.Message
+            });
+        }
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

Implements the `GET /api/RewardItem` endpoint to fetch available reward items.
An optional filter body allows narrowing results by type, name, description, cost, or effect value.

**Files added:**
- `Models/RewardItemType.cs`
- `Models/RewardItem.cs`
- `DTOs/Requests/RewardItemFilterRequestDto.cs`
- `DTOs/Responses/RewardItemResponseDto.cs`
- `Repositories/IRewardItemRepository.cs`
- `Repositories/RewardItemRepository.cs`
- `Services/IRewardItemService.cs`
- `Services/RewardItemService.cs`
- `Controllers/RewardItemController.cs`

**Files modified:**
- `Data/AppDbContext.cs` — EF mapping for `LULM_REWARD_ITEM_TYPE` and `LULM_REWARD_ITEM`
- `Program.cs` — DI registration of repository and service

---

## 🎯 Purpose

Exposes the reward item catalog so the client can display available items in the in-app shop,
with optional filtering to support type-based browsing.

---

## 🔄 Type of Change

- [x] ✨ New feature

---

## 🧪 How Has This Been Tested?

- [x] Manual testing

Manual tests against the local PostgreSQL Docker container (`leveluplife-db`):

| Scenario | Request | Expected | Result |
|---|---|---|---|
| All items | `GET /api/RewardItem` (no body) | 200 + 7 items | ✅ |
| Filter by type | `GET /api/RewardItem` `{ "ID_REWARD_ITEM_TYPE": 1 }` | 200 + 2 items (Pociones) | ✅ |
| Filter by type | `GET /api/RewardItem` `{ "ID_REWARD_ITEM_TYPE": 3 }` | 200 + 2 items (Mascotas) | ✅ |

---

## 📸 Screenshots (if applicable)

<img width="1541" height="920" alt="image" src="https://github.com/user-attachments/assets/e531e420-23aa-4617-8a39-d6d2c751dcc8" />

---

## 🚀 Deployment Notes (if needed)

No migrations required. Tables `LULM_REWARD_ITEM_TYPE` and `LULM_REWARD_ITEM`
already exist in the database. Only EF model mapping was added.

---

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #42
Linked to #
