### PR TITLE
Add TimerCriteria feature for habit tasks

### DIFF
--- a/Controllers/HabitTaskController.cs
+++ b/Controllers/HabitTaskController.cs
@@ -14,18 +14,15 @@ public class HabitTaskController : ControllerBase
     private readonly IHabitService _habitService;
     private readonly IHabitTaskService _habitTaskService;
     private readonly IRepetitionCriteriaService _repetitionCriteriaService;
-    private readonly ITimerCriteriaService _timerCriteriaService;
 
     public HabitTaskController(
         IHabitService habitService,
         IHabitTaskService habitTaskService,
-        IRepetitionCriteriaService repetitionCriteriaService,
-        ITimerCriteriaService timerCriteriaService)
+        IRepetitionCriteriaService repetitionCriteriaService)
     {
         _habitService = habitService;
         _habitTaskService = habitTaskService;
         _repetitionCriteriaService = repetitionCriteriaService;
-        _timerCriteriaService = timerCriteriaService;
     }
 
     [HttpPost]
@@ -126,55 +123,6 @@ public class HabitTaskController : ControllerBase
                 Message = "An unexpected error occurred.",
                 Details = ex.Message
             });
-        }
-    }
-
-    [HttpPost("{taskId:int}/timer-criteria")]
-    public async Task<IActionResult> CreateTimerCriteria(int taskId, [FromBody] CreateTimerCriteriaRequestDto request)
-    {
-        if (!ModelState.IsValid)
-        {
-            return ValidationProblem(ModelState);
-        }
-
-        try
-        {
-            var created = await _timerCriteriaService.CreateAsync(taskId, request);
-            return StatusCode(StatusCodes.Status201Created, created);
-        }
-        catch (ConflictError ex) when (ex.Payload.Message == "CRITERIA_ALREADY_EXISTS")
-        {
-            return Conflict(
-                new
-                {
-                    code = "CRITERIA_ALREADY_EXISTS",
-                    message = "A timer criteria already exists for this task.",
-                    details = ex.Payload.Details,
-                }
-            );
-        }
-        catch (NotFoundError ex)
-        {
-            return NotFound(
-                new
-                {
-                    code = "TASK_NOT_FOUND",
-                    message = ex.Payload.Message,
-                    details = ex.Payload.Details,
-                }
-            );
-        }
-        catch (Exception)
-        {
-            return StatusCode(
-                StatusCodes.Status500InternalServerError,
-                new
-                {
-                    code = "SERVER_ERROR",
-                    message = "Internal server error",
-                    details = "An unexpected error occurred while creating the timer criteria.",
-                }
-            );
         }
     }
 

--- a/Controllers/HabitTaskController.cs
+++ b/Controllers/HabitTaskController.cs
@@ -14,15 +14,18 @@ public class HabitTaskController : ControllerBase
     private readonly IHabitService _habitService;
     private readonly IHabitTaskService _habitTaskService;
     private readonly IRepetitionCriteriaService _repetitionCriteriaService;
+    private readonly ITimerCriteriaService _timerCriteriaService;
 
     public HabitTaskController(
         IHabitService habitService,
         IHabitTaskService habitTaskService,
-        IRepetitionCriteriaService repetitionCriteriaService)
+        IRepetitionCriteriaService repetitionCriteriaService,
+        ITimerCriteriaService timerCriteriaService)
     {
         _habitService = habitService;
         _habitTaskService = habitTaskService;
         _repetitionCriteriaService = repetitionCriteriaService;
+        _timerCriteriaService = timerCriteriaService;
     }
 
     [HttpPost]
@@ -123,6 +126,55 @@ public class HabitTaskController : ControllerBase
                 Message = "An unexpected error occurred.",
                 Details = ex.Message
             });
+        }
+    }
+
+    [HttpPost("{taskId:int}/timer-criteria")]
+    public async Task<IActionResult> CreateTimerCriteria(int taskId, [FromBody] CreateTimerCriteriaRequestDto request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var created = await _timerCriteriaService.CreateAsync(taskId, request);
+            return StatusCode(StatusCodes.Status201Created, created);
+        }
+        catch (ConflictError ex) when (ex.Payload.Message == "CRITERIA_ALREADY_EXISTS")
+        {
+            return Conflict(
+                new
+                {
+                    code = "CRITERIA_ALREADY_EXISTS",
+                    message = "A timer criteria already exists for this task.",
+                    details = ex.Payload.Details,
+                }
+            );
+        }
+        catch (NotFoundError ex)
+        {
+            return NotFound(
+                new
+                {
+                    code = "TASK_NOT_FOUND",
+                    message = ex.Payload.Message,
+                    details = ex.Payload.Details,
+                }
+            );
+        }
+        catch (Exception)
+        {
+            return StatusCode(
+                StatusCodes.Status500InternalServerError,
+                new
+                {
+                    code = "SERVER_ERROR",
+                    message = "Internal server error",
+                    details = "An unexpected error occurred while creating the timer criteria.",
+                }
+            );
         }
     }
 

--- a/DTOs/Requests/CreateHabitTaskRequestDto.cs
+++ b/DTOs/Requests/CreateHabitTaskRequestDto.cs
@@ -38,6 +38,7 @@ public class CreateHabitTaskRequestDto
 
     public TaskEvidence? Evidence { get; set; }
     public CreateRepetitionCriteriaRequestDto? RepetitionCriteria { get; set; }
+    public CreateTimerCriteriaRequestDto? TimerCriteria { get; set; }
 
     [Range(0, int.MaxValue, ErrorMessage = "El XP no puede ser negativo.")]
     public int? XpValue { get; set; }
@@ -59,6 +60,22 @@ public class CreateHabitTaskRequestDto
             yield return new ValidationResult(
                 "RepetitionCriteria solo debe enviarse cuando el criterio de completado es REPETITIONS.",
                 [nameof(RepetitionCriteria)]
+            );
+        }
+
+        if (CompletionCriteria == TaskCompletionCriteria.TIMER && TimerCriteria is null)
+        {
+            yield return new ValidationResult(
+                "Los criterios de timer son obligatorios cuando el criterio de completado es TIMER.",
+                [nameof(TimerCriteria)]
+            );
+        }
+
+        if (CompletionCriteria != TaskCompletionCriteria.TIMER && TimerCriteria is not null)
+        {
+            yield return new ValidationResult(
+                "TimerCriteria solo debe enviarse cuando el criterio de completado es TIMER.",
+                [nameof(TimerCriteria)]
             );
         }
 

--- a/DTOs/Requests/CreateStandaloneHabitTaskRequestDto.cs
+++ b/DTOs/Requests/CreateStandaloneHabitTaskRequestDto.cs
@@ -43,6 +43,7 @@ public class CreateStandaloneHabitTaskRequestDto : IValidatableObject
     public TaskEvidence? Evidence { get; set; }
 
     public CreateRepetitionCriteriaRequestDto? RepetitionCriteria { get; set; }
+    public CreateTimerCriteriaRequestDto? TimerCriteria { get; set; }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
@@ -59,6 +60,22 @@ public class CreateStandaloneHabitTaskRequestDto : IValidatableObject
             yield return new ValidationResult(
                 "RepetitionCriteria must be omitted unless CompletionCriteria is REPETITIONS.",
                 [nameof(RepetitionCriteria)]
+            );
+        }
+
+        if (CompletionCriteria == TaskCompletionCriteria.TIMER && TimerCriteria is null)
+        {
+            yield return new ValidationResult(
+                "TimerCriteria is required when CompletionCriteria is TIMER.",
+                [nameof(TimerCriteria)]
+            );
+        }
+
+        if (CompletionCriteria != TaskCompletionCriteria.TIMER && TimerCriteria is not null)
+        {
+            yield return new ValidationResult(
+                "TimerCriteria must be omitted unless CompletionCriteria is TIMER.",
+                [nameof(TimerCriteria)]
             );
         }
 

--- a/DTOs/Requests/CreateTimerCriteriaRequestDto.cs
+++ b/DTOs/Requests/CreateTimerCriteriaRequestDto.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LevelUpLifeBackend.DTOs.Requests;
+
+public class CreateTimerCriteriaRequestDto
+{
+    [Required(ErrorMessage = "NUM_SECONDS_DEFINED is required.")]
+    [Range(1, int.MaxValue, ErrorMessage = "NUM_SECONDS_DEFINED must be greater than 0.")]
+    public int? NUM_SECONDS_DEFINED { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "NUM_SECONDS_LONG must be greater than 0.")]
+    public int? NUM_SECONDS_LONG { get; set; }
+
+    [Required(ErrorMessage = "TYPE_PAUSE_IS_ALLOWED is required.")]
+    public bool? TYPE_PAUSE_IS_ALLOWED { get; set; }
+
+    public bool? STATUS_TIMER_CRITERIA_IS_ACTIVE { get; set; }
+}

--- a/DTOs/Responses/GetPlayerProfileResponseDto.cs
+++ b/DTOs/Responses/GetPlayerProfileResponseDto.cs
@@ -35,5 +35,5 @@ public class GetPlayerProfilePersonDataDto
     public string Email { get; set; } = string.Empty;
 
     [JsonPropertyName("birthdate")]
-    public DateOnly Birthdate { get; set; }
+    public DateOnly? Birthdate { get; set; }
 }

--- a/DTOs/Responses/HabitTaskResponseDto.cs
+++ b/DTOs/Responses/HabitTaskResponseDto.cs
@@ -21,4 +21,5 @@ public class HabitTaskResponseDto
     public TaskCompletionCriteria CompletionCriteria { get; set; }
     public TaskEvidence? Evidence { get; set; }
     public RepetitionCriteriaResponseDto? RepetitionCriteria { get; set; }
+    public TimerCriteriaResponseDto? TimerCriteria { get; set; }
 }

--- a/DTOs/Responses/TimerCriteriaResponseDto.cs
+++ b/DTOs/Responses/TimerCriteriaResponseDto.cs
@@ -1,0 +1,11 @@
+namespace LevelUpLifeBackend.DTOs.Responses;
+
+public class TimerCriteriaResponseDto
+{
+    public int Id { get; set; }
+    public int HabitTaskId { get; set; }
+    public int NumSecondsDefined { get; set; }
+    public int? NumSecondsLong { get; set; }
+    public bool TypePauseIsAllowed { get; set; }
+    public bool StatusTimerCriteriaIsActive { get; set; }
+}

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -20,6 +20,7 @@ public class AppDbContext : DbContext
     public DbSet<Habit> Habits { get; set; }
     public DbSet<HabitTask> HabitTasks { get; set; }
     public DbSet<RepetitionCriteria> RepetitionCriteriaRecords { get; set; }
+    public DbSet<TimerCriteria> TimerCriteriaRecords { get; set; }
     public DbSet<EvidenceStorage> EvidenceStorages { get; set; }
 
     public DbSet<RewardItemType> RewardItemTypes { get; set; }
@@ -201,6 +202,24 @@ public class AppDbContext : DbContext
             entity.Property(e => e.StatusIsPartialAllowed).HasColumnName("STATUS_IS_PARTIAL_ALLOWED");
             entity.Property(e => e.StatusRepetitionsCriteriaIsActive)
                   .HasColumnName("STATUS_REPETITIONS_CRITERIA_IS_ACTIVE");
+        });
+
+        modelBuilder.Entity<TimerCriteria>(entity =>
+        {
+            entity.ToTable("LULT_HABIT_TASK_TIMER_CRITERIA");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasColumnName("ID_HABIT_TASK_TIMER_CRITERIA");
+
+            entity.Property(e => e.HabitTaskId).HasColumnName("ID_HABIT_TASK");
+            entity.HasOne(e => e.HabitTask)
+                  .WithOne(ht => ht.TimerCriteria)
+                  .HasForeignKey<TimerCriteria>(e => e.HabitTaskId)
+                  .OnDelete(DeleteBehavior.Cascade);
+
+            entity.Property(e => e.NumSecondsDefined).HasColumnName("NUM_SECONDS_DEFINED");
+            entity.Property(e => e.NumSecondsLong).HasColumnName("NUM_SECONDS_LONG");
+            entity.Property(e => e.TypePauseIsAllowed).HasColumnName("TYPE_PAUSE_IS_ALLOWED");
+            entity.Property(e => e.StatusTimerCriteriaIsActive).HasColumnName("STATUS_TIMER_CRITERIA_IS_ACTIVE");
         });
 
         modelBuilder.Entity<EvidenceStorage>(entity =>

--- a/Mappers/HabitTaskMapper.cs
+++ b/Mappers/HabitTaskMapper.cs
@@ -80,6 +80,9 @@ public static class HabitTaskMapper
             RepetitionCriteria = task.RepetitionCriteria is null
                 ? null
                 : RepetitionCriteriaMapper.ToResponse(task.RepetitionCriteria),
+            TimerCriteria = task.TimerCriteria is null
+                ? null
+                : TimerCriteriaMapper.ToResponse(task.TimerCriteria),
         };
     }
 }

--- a/Mappers/TimerCriteriaMapper.cs
+++ b/Mappers/TimerCriteriaMapper.cs
@@ -1,0 +1,33 @@
+using LevelUpLifeBackend.DTOs.Requests;
+using LevelUpLifeBackend.DTOs.Responses;
+using LevelUpLifeBackend.Models;
+
+namespace LevelUpLifeBackend.Mappers;
+
+public static class TimerCriteriaMapper
+{
+    public static TimerCriteria ToEntity(int taskId, CreateTimerCriteriaRequestDto dto)
+    {
+        return new TimerCriteria
+        {
+            HabitTaskId = taskId,
+            NumSecondsDefined = dto.NUM_SECONDS_DEFINED ?? 0,
+            NumSecondsLong = dto.NUM_SECONDS_LONG,
+            TypePauseIsAllowed = dto.TYPE_PAUSE_IS_ALLOWED ?? false,
+            StatusTimerCriteriaIsActive = dto.STATUS_TIMER_CRITERIA_IS_ACTIVE ?? true,
+        };
+    }
+
+    public static TimerCriteriaResponseDto ToResponse(TimerCriteria entity)
+    {
+        return new TimerCriteriaResponseDto
+        {
+            Id = entity.Id,
+            HabitTaskId = entity.HabitTaskId,
+            NumSecondsDefined = entity.NumSecondsDefined,
+            NumSecondsLong = entity.NumSecondsLong,
+            TypePauseIsAllowed = entity.TypePauseIsAllowed,
+            StatusTimerCriteriaIsActive = entity.StatusTimerCriteriaIsActive,
+        };
+    }
+}

--- a/Models/HabitTask.cs
+++ b/Models/HabitTask.cs
@@ -8,6 +8,7 @@ public class HabitTask
     public int? HabitDisciplineId { get; set; }
     public HabitDiscipline? HabitDiscipline { get; set; }
     public RepetitionCriteria? RepetitionCriteria { get; set; }
+    public TimerCriteria? TimerCriteria { get; set; }
 
     public string Title { get; set; } = string.Empty;
     public string? Description { get; set; }

--- a/Models/TimerCriteria.cs
+++ b/Models/TimerCriteria.cs
@@ -1,0 +1,22 @@
+namespace LevelUpLifeBackend.Models;
+
+public class TimerCriteria
+{
+    public int Id { get; set; }
+    public int HabitTaskId { get; set; }
+    public HabitTask? HabitTask { get; set; }
+    public int NumSecondsDefined { get; set; }
+    public int? NumSecondsLong { get; set; }
+    public bool TypePauseIsAllowed { get; set; }
+    public bool StatusTimerCriteriaIsActive { get; set; }
+
+    public TimerCriteria()
+    {
+        Id = 0;
+        HabitTaskId = 0;
+        NumSecondsDefined = 0;
+        NumSecondsLong = null;
+        TypePauseIsAllowed = false;
+        StatusTimerCriteriaIsActive = true;
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -67,6 +67,8 @@ builder.Services.AddScoped<IHabitTaskRepository, HabitTaskRepository>();
 builder.Services.AddScoped<IHabitTaskService, HabitTaskService>();
 builder.Services.AddScoped<IRepetitionCriteriaRepository, RepetitionCriteriaRepository>();
 builder.Services.AddScoped<IRepetitionCriteriaService, RepetitionCriteriaService>();
+builder.Services.AddScoped<ITimerCriteriaRepository, TimerCriteriaRepository>();
+builder.Services.AddScoped<ITimerCriteriaService, TimerCriteriaService>();
 
 builder.Services.AddScoped<IRewardItemRepository, RewardItemRepository>();
 builder.Services.AddScoped<IRewardItemService, RewardItemService>();

--- a/Program.cs
+++ b/Program.cs
@@ -68,7 +68,6 @@ builder.Services.AddScoped<IHabitTaskService, HabitTaskService>();
 builder.Services.AddScoped<IRepetitionCriteriaRepository, RepetitionCriteriaRepository>();
 builder.Services.AddScoped<IRepetitionCriteriaService, RepetitionCriteriaService>();
 builder.Services.AddScoped<ITimerCriteriaRepository, TimerCriteriaRepository>();
-builder.Services.AddScoped<ITimerCriteriaService, TimerCriteriaService>();
 
 builder.Services.AddScoped<IRewardItemRepository, RewardItemRepository>();
 builder.Services.AddScoped<IRewardItemService, RewardItemService>();

--- a/Repositories/HabitTaskRepository.cs
+++ b/Repositories/HabitTaskRepository.cs
@@ -30,6 +30,7 @@ public class HabitTaskRepository : IHabitTaskRepository
         return _context.HabitTasks
             .AsNoTracking()
             .Include(t => t.RepetitionCriteria)
+            .Include(t => t.TimerCriteria)
             .FirstOrDefaultAsync(t => t.Id == id);
     }
 

--- a/Repositories/ITimerCriteriaRepository.cs
+++ b/Repositories/ITimerCriteriaRepository.cs
@@ -1,0 +1,9 @@
+using LevelUpLifeBackend.Models;
+
+namespace LevelUpLifeBackend.Repositories;
+
+public interface ITimerCriteriaRepository
+{
+    Task<TimerCriteria> AddAsync(TimerCriteria criteria);
+    Task<TimerCriteria?> GetByTaskIdAsync(int taskId);
+}

--- a/Repositories/TimerCriteriaRepository.cs
+++ b/Repositories/TimerCriteriaRepository.cs
@@ -1,0 +1,28 @@
+using LevelUpLifeBackend.Data;
+using LevelUpLifeBackend.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace LevelUpLifeBackend.Repositories;
+
+public class TimerCriteriaRepository : ITimerCriteriaRepository
+{
+    private readonly AppDbContext _context;
+
+    public TimerCriteriaRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<TimerCriteria> AddAsync(TimerCriteria criteria)
+    {
+        await _context.TimerCriteriaRecords.AddAsync(criteria);
+        await _context.SaveChangesAsync();
+        return criteria;
+    }
+
+    public async Task<TimerCriteria?> GetByTaskIdAsync(int taskId)
+    {
+        return await _context.TimerCriteriaRecords
+            .FirstOrDefaultAsync(c => c.HabitTaskId == taskId);
+    }
+}

--- a/Services/HabitService.cs
+++ b/Services/HabitService.cs
@@ -14,17 +14,20 @@ public class HabitService : IHabitService
     private readonly IHabitRepository _habitRepository;
     private readonly IHabitTaskRepository _habitTaskRepository;
     private readonly IRepetitionCriteriaRepository _repetitionCriteriaRepository;
+    private readonly ITimerCriteriaRepository _timerCriteriaRepository;
     private readonly AppDbContext _context;
 
     public HabitService(
         IHabitRepository habitRepository,
         IHabitTaskRepository habitTaskRepository,
         IRepetitionCriteriaRepository repetitionCriteriaRepository,
+        ITimerCriteriaRepository timerCriteriaRepository,
         AppDbContext context)
     {
         _habitRepository = habitRepository;
         _habitTaskRepository = habitTaskRepository;
         _repetitionCriteriaRepository = repetitionCriteriaRepository;
+        _timerCriteriaRepository = timerCriteriaRepository;
         _context = context;
     }
 
@@ -48,10 +51,23 @@ public class HabitService : IHabitService
                         RepetitionCriteriaMapper.ToEntity(task.Id, taskDto.RepetitionCriteria!)
                     );
                 }
+
+                TimerCriteria? timerCriteria = null;
+                if (taskDto.CompletionCriteria == TaskCompletionCriteria.TIMER)
+                {
+                    timerCriteria = await _timerCriteriaRepository.AddAsync(
+                        TimerCriteriaMapper.ToEntity(task.Id, taskDto.TimerCriteria!)
+                    );
+                }
+
                 var taskResponse = HabitTaskMapper.ToResponse(task);
                 if (criteria is not null)
                 {
                     taskResponse.RepetitionCriteria = RepetitionCriteriaMapper.ToResponse(criteria);
+                }
+                if (timerCriteria is not null)
+                {
+                    taskResponse.TimerCriteria = TimerCriteriaMapper.ToResponse(timerCriteria);
                 }
                 taskResponses.Add(taskResponse);
             }
@@ -129,6 +145,14 @@ public class HabitService : IHabitService
                 );
             }
 
+            TimerCriteria? timerCriteria = null;
+            if (request.CompletionCriteria == TaskCompletionCriteria.TIMER)
+            {
+                timerCriteria = await _timerCriteriaRepository.AddAsync(
+                    TimerCriteriaMapper.ToEntity(task.Id, request.TimerCriteria!)
+                );
+            }
+
             await transaction.CommitAsync();
 
             var created = await _habitTaskRepository.GetByIdWithCriteriaAsync(task.Id);
@@ -136,6 +160,10 @@ public class HabitService : IHabitService
             if (criteria is not null)
             {
                 response.RepetitionCriteria = RepetitionCriteriaMapper.ToResponse(criteria);
+            }
+            if (timerCriteria is not null)
+            {
+                response.TimerCriteria = TimerCriteriaMapper.ToResponse(timerCriteria);
             }
             return response;
         }

--- a/Services/ITimerCriteriaService.cs
+++ b/Services/ITimerCriteriaService.cs
@@ -1,0 +1,9 @@
+using LevelUpLifeBackend.DTOs.Requests;
+using LevelUpLifeBackend.DTOs.Responses;
+
+namespace LevelUpLifeBackend.Services;
+
+public interface ITimerCriteriaService
+{
+    Task<TimerCriteriaResponseDto> CreateAsync(int taskId, CreateTimerCriteriaRequestDto request);
+}

--- a/Services/TimerCriteriaService.cs
+++ b/Services/TimerCriteriaService.cs
@@ -1,0 +1,70 @@
+using LevelUpLifeBackend.DTOs.Requests;
+using LevelUpLifeBackend.DTOs.Responses;
+using LevelUpLifeBackend.Infrastructure.Errors;
+using LevelUpLifeBackend.Mappers;
+using LevelUpLifeBackend.Repositories;
+
+namespace LevelUpLifeBackend.Services;
+
+public class TimerCriteriaService : ITimerCriteriaService
+{
+    private readonly ITimerCriteriaRepository _timerCriteriaRepository;
+    private readonly IHabitTaskRepository _habitTaskRepository;
+
+    public TimerCriteriaService(
+        ITimerCriteriaRepository timerCriteriaRepository,
+        IHabitTaskRepository habitTaskRepository)
+    {
+        _timerCriteriaRepository = timerCriteriaRepository;
+        _habitTaskRepository = habitTaskRepository;
+    }
+
+    public async Task<TimerCriteriaResponseDto> CreateAsync(int taskId, CreateTimerCriteriaRequestDto request)
+    {
+        try
+        {
+            var taskExists = await _habitTaskRepository.ExistsAsync(taskId);
+            if (!taskExists)
+            {
+                throw new NotFoundError(new ErrorResponse
+                {
+                    Code = 404,
+                    Message = $"Habit task with ID {taskId} not found.",
+                    Details = "The specified task does not exist."
+                });
+            }
+
+            var existing = await _timerCriteriaRepository.GetByTaskIdAsync(taskId);
+            if (existing is not null)
+            {
+                throw new ConflictError(new ErrorResponse
+                {
+                    Code = 409,
+                    Message = "CRITERIA_ALREADY_EXISTS",
+                    Details = $"A timer criteria already exists for task {taskId}."
+                });
+            }
+
+            var entity = TimerCriteriaMapper.ToEntity(taskId, request);
+            var created = await _timerCriteriaRepository.AddAsync(entity);
+            return TimerCriteriaMapper.ToResponse(created);
+        }
+        catch (NotFoundError)
+        {
+            throw;
+        }
+        catch (ConflictError)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new ServerError(500, new ErrorResponse
+            {
+                Code = 500,
+                Message = "An unexpected error occurred while creating the timer criteria.",
+                Details = ex.Message
+            });
+        }
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

Implements the `POST /api/habit-tasks/{taskId}/timer-criteria` endpoint to create a timer criteria record for a habit task. Only one record is allowed per task, enforced at the service level with a 409 response.

New files added: `TimerCriteria` model, request/response DTOs, mapper, repository (interface + implementation), and service (interface + implementation). Existing files updated: `HabitTask`, `AppDbContext`, `HabitTaskController`, and `Program.cs`. A new EF Core migration (`AddTimerCriteria`) was generated to create the `LULT_HABIT_TASK_TIMER_CRITERIA` table.

---

## 🎯 Purpose

Tasks with `CompletionCriteria = TIMER` had no way to store their timer configuration. This PR provides the full persistence and API layer for that criteria, following the exact same patterns already established by `RepetitionCriteria`.

---

## 🔄 Type of Change

Please check the relevant option:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

All scenarios were tested manually via Scalar against a local PostgreSQL 16 Docker container:

| Scenario | Request | Expected | Result |
|---|---|---|---|
| ✅ 201 Created | Valid `taskId` + valid body | Returns `TimerCriteria` object | ✅ Pass |
| ✅ 409 Conflict | Same `taskId` called twice | `CRITERIA_ALREADY_EXISTS` error | ✅ Pass |
| ✅ 404 Not Found | Non-existent `taskId` (e.g. 9999) | `TASK_NOT_FOUND` error | ✅ Pass |
| ✅ 400 Bad Request | Missing `NUM_SECONDS_DEFINED` | Field-level validation errors | ✅ Pass |

---

## 📸 Screenshots (if applicable)

<img width="1407" height="831" alt="image" src="https://github.com/user-attachments/assets/7e0bcdda-6976-43ac-a1f8-67f3a8b4a7cd" />

<img width="1422" height="868" alt="image" src="https://github.com/user-attachments/assets/e78c172c-b6f5-45ae-808d-0f8c985d25dc" />

<img width="1402" height="833" alt="image" src="https://github.com/user-attachments/assets/c24f3f68-22f6-4fc6-a4de-bc20111c3c70" />

---

## 🚀 Deployment Notes (if needed)

- Run the EF Core migration before deploying: `dotnet ef database update`
- Or apply the generated SQL from `Migrations/20260528225252_AddTimerCriteria.cs` manually, which creates the `LULT_HABIT_TASK_TIMER_CRITERIA` table with a unique FK constraint on `ID_HABIT_TASK`.

---

## ✅ Checklist

Before requesting a review, please confirm:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #35
