### PR TITLE
Feature/27 update habit task

### DIFF
--- a/Controllers/HabitController.cs
+++ b/Controllers/HabitController.cs
@@ -178,7 +178,6 @@ public class HabitsController : ControllerBase
 
         try
         {
-            //var userIdString = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
             var userIdString = Request.Headers["X-User-Id"].FirstOrDefault();
 
             if (string.IsNullOrEmpty(userIdString) || !int.TryParse(userIdString, out int userId))

--- a/Controllers/HabitTaskController.cs
+++ b/Controllers/HabitTaskController.cs
@@ -51,17 +51,6 @@ public class HabitTaskController : ControllerBase
             var created = await _habitService.CreateTaskAsync(request, userId.Value);
             return StatusCode(StatusCodes.Status201Created, created);
         }
-        catch (ConflictError ex) when (ex.Payload.Message == "TASK_ALREADY_EXISTS")
-        {
-            return Conflict(
-                new
-                {
-                    code = "TASK_ALREADY_EXISTS",
-                    message = "Task already exists for this habit",
-                    details = ex.Payload.Details,
-                }
-            );
-        }
         catch (NotFoundError ex)
         {
             return NotFound(

--- a/Controllers/HabitTaskController.cs
+++ b/Controllers/HabitTaskController.cs
@@ -99,6 +99,80 @@ public class HabitTaskController : ControllerBase
         }
     }
 
+    [HttpPut("{id:int}")]
+    public async Task<IActionResult> Update(int id, [FromBody] CreateStandaloneHabitTaskRequestDto request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        var userId = ResolveUserId();
+        if (userId is null)
+        {
+            return Unauthorized(
+                new
+                {
+                    code = "UNAUTHORIZED",
+                    message = "Unauthorized access",
+                    details = "A valid JWT or X-User-Id header is required.",
+                }
+            );
+        }
+
+        try
+        {
+            var updated = await _habitService.UpdateTaskAsync(id, request, userId.Value);
+            return Ok(updated);
+        }
+        catch (NotFoundError ex)
+        {
+            return NotFound(
+                new
+                {
+                    code = "TASK_NOT_FOUND",
+                    message = ex.Payload.Message,
+                    details = ex.Payload.Details,
+                }
+            );
+        }
+        catch (AuthError ex) when (ex.Kind == AuthFailureKind.Forbidden)
+        {
+            return StatusCode(
+                StatusCodes.Status403Forbidden,
+                new
+                {
+                    code = "FORBIDDEN",
+                    message = ex.Payload.Message,
+                    details = ex.Payload.Details,
+                }
+            );
+        }
+        catch (AppError ex) when (ex.HttpStatusCode == StatusCodes.Status400BadRequest)
+        {
+            return BadRequest(
+                new
+                {
+                    code = "VALIDATION_ERROR",
+                    message = ex.Payload.Message,
+                    details = ex.Payload.Details,
+                }
+            );
+        }
+        catch (Exception)
+        {
+            return StatusCode(
+                StatusCodes.Status500InternalServerError,
+                new
+                {
+                    code = "SERVER_ERROR",
+                    message = "Internal server error",
+                    details = "An unexpected error occurred while updating the habit task.",
+                }
+            );
+        }
+    }
+
     [HttpGet("{taskId:int}/evidences")]
     public async Task<IActionResult> GetEvidences(int taskId)
     {

--- a/DTOs/Requests/UpdateHabitTaskRequestDto.cs
+++ b/DTOs/Requests/UpdateHabitTaskRequestDto.cs
@@ -1,12 +1,63 @@
 using System.ComponentModel.DataAnnotations;
+using LevelUpLifeBackend.Models;
 
 namespace LevelUpLifeBackend.DTOs.Requests;
 
-public class UpdateHabitTaskRequestDto
+public class UpdateHabitTaskRequestDto : IValidatableObject
 {
     [Required(ErrorMessage = "El identificador de la tarea es obligatorio.")]
     [Range(1, int.MaxValue, ErrorMessage = "La tarea no es válida.")]
     public int TaskId { get; set; }
 
+    [Range(1, int.MaxValue, ErrorMessage = "HabitDisciplineId must be greater than 0.")]
+    public int? HabitDisciplineId { get; set; }
+
+    [StringLength(100, MinimumLength = 3, ErrorMessage = "Title must be between 3 and 100 characters.")]
+    public string? Title { get; set; }
+
+    public string? Description { get; set; }
+
+    [Range(0, int.MaxValue, ErrorMessage = "XpValue cannot be negative.")]
+    public int? XpValue { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "PeriodLength must be greater than 0.")]
+    public int? PeriodLength { get; set; }
+
+    public DateOnly? StartDate { get; set; }
+    public bool? IsActive { get; set; }
+    public string? WeekDays { get; set; }
+    public TaskDifficulty? Difficulty { get; set; }
+    public TaskFrequency? Frequency { get; set; }
+    public TaskPeriodUnit? PeriodUnit { get; set; }
+    public TaskCompletionCriteria? CompletionCriteria { get; set; }
+    public TaskEvidence? Evidence { get; set; }
+
     public UpdateRepetitionCriteriaRequestDto? RepetitionCriteria { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (CompletionCriteria == TaskCompletionCriteria.REPETITIONS && RepetitionCriteria is null)
+        {
+            yield return new ValidationResult(
+                "RepetitionCriteria is required when CompletionCriteria is REPETITIONS.",
+                [nameof(RepetitionCriteria)]
+            );
+        }
+
+        if (CompletionCriteria != TaskCompletionCriteria.REPETITIONS && RepetitionCriteria is not null)
+        {
+            yield return new ValidationResult(
+                "RepetitionCriteria must be omitted unless CompletionCriteria is REPETITIONS.",
+                [nameof(RepetitionCriteria)]
+            );
+        }
+
+        if (CompletionCriteria != TaskCompletionCriteria.EVIDENCE && Evidence is not null)
+        {
+            yield return new ValidationResult(
+                "Evidence must be omitted unless CompletionCriteria is EVIDENCE.",
+                [nameof(Evidence)]
+            );
+        }
+    }
 }

--- a/LevelUpLife-Backend.Tests/HabitServiceUpdateTaskTests.cs
+++ b/LevelUpLife-Backend.Tests/HabitServiceUpdateTaskTests.cs
@@ -24,13 +24,12 @@ public class HabitServiceUpdateTaskTests
 
     private static HabitService CreateService(
         AppDbContext context,
-        Mock<IHabitTaskRepository> taskRepo,
-        Mock<IRepetitionCriteriaRepository>? criteriaRepo = null
+        Mock<IHabitTaskRepository> taskRepo
     )
     {
         var habitRepo = new Mock<IHabitRepository>();
-        var criteria = criteriaRepo ?? new Mock<IRepetitionCriteriaRepository>();
-        return new HabitService(habitRepo.Object, taskRepo.Object, criteria.Object, context);
+        var criteriaRepo = new Mock<IRepetitionCriteriaRepository>();
+        return new HabitService(habitRepo.Object, taskRepo.Object, criteriaRepo.Object, context);
     }
 
     private static HabitTask SampleTask(int taskId = 1, int habitId = 10, int userId = 2)
@@ -101,27 +100,20 @@ public class HabitServiceUpdateTaskTests
         await using var context = CreateInMemoryContext();
         var task = SampleTask();
         var taskRepo = new Mock<IHabitTaskRepository>();
-        var criteriaRepo = new Mock<IRepetitionCriteriaRepository>();
 
+        taskRepo.Setup(r => r.GetTrackedByIdForUserAsync(1, 2)).ReturnsAsync(task);
         taskRepo
-            .Setup(r => r.GetTrackedByIdForUserAsync(1, 2))
-            .ReturnsAsync(task);
-        taskRepo.Setup(r => r.UpdateAsync(It.IsAny<HabitTask>())).Returns(Task.CompletedTask);
-        criteriaRepo
-            .Setup(r => r.UpdateAsync(It.IsAny<RepetitionCriteria>()))
-            .ReturnsAsync((RepetitionCriteria c) => c);
+            .Setup(r => r.UpdateWithRepetitionCriteriaAsync(It.IsAny<HabitTask>()))
+            .Returns(Task.CompletedTask);
 
-        var service = CreateService(context, taskRepo, criteriaRepo);
-        var request = ValidUpdateRequest();
-
-        var result = await service.UpdateTaskAsync(1, request, userId: 2);
+        var service = CreateService(context, taskRepo);
+        var result = await service.UpdateTaskAsync(1, ValidUpdateRequest(), userId: 2);
 
         Assert.Equal("Updated title", result.Title);
         Assert.Equal(TaskDifficulty.HARD, result.Difficulty);
         Assert.NotNull(result.RepetitionCriteria);
         Assert.Equal(5, result.RepetitionCriteria!.Repetitions);
-        taskRepo.Verify(r => r.UpdateAsync(It.IsAny<HabitTask>()), Times.Once);
-        criteriaRepo.Verify(r => r.UpdateAsync(It.IsAny<RepetitionCriteria>()), Times.Once);
+        taskRepo.Verify(r => r.UpdateWithRepetitionCriteriaAsync(It.IsAny<HabitTask>()), Times.Once);
     }
 
     [Fact]
@@ -147,10 +139,9 @@ public class HabitServiceUpdateTaskTests
         taskRepo.Setup(r => r.GetTrackedByIdForUserAsync(1, 2)).ReturnsAsync(task);
 
         var service = CreateService(context, taskRepo);
-        var request = ValidUpdateRequest(habitId: 999);
 
         var ex = await Assert.ThrowsAsync<AppError>(() =>
-            service.UpdateTaskAsync(1, request, userId: 2)
+            service.UpdateTaskAsync(1, ValidUpdateRequest(habitId: 999), userId: 2)
         );
         Assert.Equal(400, ex.HttpStatusCode);
     }

--- a/LevelUpLife-Backend.Tests/HabitServiceUpdateTaskTests.cs
+++ b/LevelUpLife-Backend.Tests/HabitServiceUpdateTaskTests.cs
@@ -1,0 +1,157 @@
+using LevelUpLifeBackend.Data;
+using LevelUpLifeBackend.DTOs.Requests;
+using LevelUpLifeBackend.Infrastructure.Errors;
+using LevelUpLifeBackend.Models;
+using LevelUpLifeBackend.Repositories;
+using LevelUpLifeBackend.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Moq;
+using Xunit;
+
+namespace LevelUpLife_Backend.Tests;
+
+public class HabitServiceUpdateTaskTests
+{
+    private static AppDbContext CreateInMemoryContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static HabitService CreateService(
+        AppDbContext context,
+        Mock<IHabitTaskRepository> taskRepo,
+        Mock<IRepetitionCriteriaRepository>? criteriaRepo = null
+    )
+    {
+        var habitRepo = new Mock<IHabitRepository>();
+        var criteria = criteriaRepo ?? new Mock<IRepetitionCriteriaRepository>();
+        return new HabitService(habitRepo.Object, taskRepo.Object, criteria.Object, context);
+    }
+
+    private static HabitTask SampleTask(int taskId = 1, int habitId = 10, int userId = 2)
+    {
+        var user = new PlayerUser { Id = userId, UserName = "testuser" };
+        var category = new HabitCategory { Id = 1, Name = "Salud" };
+        var discipline = new HabitDiscipline
+        {
+            Id = 3,
+            Name = "Ejercicio",
+            Category = category,
+        };
+        var habit = new Habit
+        {
+            Id = habitId,
+            Title = "Habit",
+            IsActive = true,
+            User = user,
+            Discipline = discipline,
+        };
+
+        return new HabitTask
+        {
+            Id = taskId,
+            HabitId = habitId,
+            Habit = habit,
+            HabitDisciplineId = discipline.Id,
+            Title = "Old title",
+            Difficulty = TaskDifficulty.EASY,
+            Frequency = TaskFrequency.DAILY,
+            PeriodLength = 1,
+            PeriodUnit = TaskPeriodUnit.DAYS,
+            StartDate = DateOnly.FromDateTime(DateTime.UtcNow),
+            CompletionCriteria = TaskCompletionCriteria.REPETITIONS,
+            IsActive = true,
+            RepetitionCriteria = new RepetitionCriteria
+            {
+                Id = 5,
+                HabitTaskId = taskId,
+                NumRepetitionsObjective = 2,
+                TypeUnityMeasurementUnit = MeasurementUnit.SERIES,
+            },
+        };
+    }
+
+    private static CreateStandaloneHabitTaskRequestDto ValidUpdateRequest(int habitId = 10) =>
+        new()
+        {
+            HabitId = habitId,
+            Title = "Updated title",
+            Difficulty = TaskDifficulty.HARD,
+            Frequency = TaskFrequency.WEEKLY,
+            PeriodLength = 2,
+            PeriodUnit = TaskPeriodUnit.WEEKS,
+            StartDate = DateOnly.FromDateTime(DateTime.UtcNow),
+            CompletionCriteria = TaskCompletionCriteria.REPETITIONS,
+            RepetitionCriteria = new CreateRepetitionCriteriaRequestDto
+            {
+                Repetitions = 5,
+                MeasurementUnit = MeasurementUnit.REPS,
+                IsPartialAllowed = true,
+            },
+        };
+
+    [Fact]
+    public async Task UpdateTaskAsync_WhenTaskExists_ReturnsUpdatedTask()
+    {
+        await using var context = CreateInMemoryContext();
+        var task = SampleTask();
+        var taskRepo = new Mock<IHabitTaskRepository>();
+        var criteriaRepo = new Mock<IRepetitionCriteriaRepository>();
+
+        taskRepo
+            .Setup(r => r.GetTrackedByIdForUserAsync(1, 2))
+            .ReturnsAsync(task);
+        taskRepo.Setup(r => r.UpdateAsync(It.IsAny<HabitTask>())).Returns(Task.CompletedTask);
+        criteriaRepo
+            .Setup(r => r.UpdateAsync(It.IsAny<RepetitionCriteria>()))
+            .ReturnsAsync((RepetitionCriteria c) => c);
+
+        var service = CreateService(context, taskRepo, criteriaRepo);
+        var request = ValidUpdateRequest();
+
+        var result = await service.UpdateTaskAsync(1, request, userId: 2);
+
+        Assert.Equal("Updated title", result.Title);
+        Assert.Equal(TaskDifficulty.HARD, result.Difficulty);
+        Assert.NotNull(result.RepetitionCriteria);
+        Assert.Equal(5, result.RepetitionCriteria!.Repetitions);
+        taskRepo.Verify(r => r.UpdateAsync(It.IsAny<HabitTask>()), Times.Once);
+        criteriaRepo.Verify(r => r.UpdateAsync(It.IsAny<RepetitionCriteria>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_WhenTaskNotFound_ThrowsNotFoundError()
+    {
+        await using var context = CreateInMemoryContext();
+        var taskRepo = new Mock<IHabitTaskRepository>();
+        taskRepo.Setup(r => r.GetTrackedByIdForUserAsync(99, 2)).ReturnsAsync((HabitTask?)null);
+
+        var service = CreateService(context, taskRepo);
+
+        await Assert.ThrowsAsync<NotFoundError>(() =>
+            service.UpdateTaskAsync(99, ValidUpdateRequest(), userId: 2)
+        );
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_WhenHabitIdMismatch_ThrowsAppError400()
+    {
+        await using var context = CreateInMemoryContext();
+        var task = SampleTask(habitId: 10);
+        var taskRepo = new Mock<IHabitTaskRepository>();
+        taskRepo.Setup(r => r.GetTrackedByIdForUserAsync(1, 2)).ReturnsAsync(task);
+
+        var service = CreateService(context, taskRepo);
+        var request = ValidUpdateRequest(habitId: 999);
+
+        var ex = await Assert.ThrowsAsync<AppError>(() =>
+            service.UpdateTaskAsync(1, request, userId: 2)
+        );
+        Assert.Equal(400, ex.HttpStatusCode);
+    }
+}

--- a/LevelUpLife-Backend.Tests/LevelUpLife-Backend.Tests.csproj
+++ b/LevelUpLife-Backend.Tests/LevelUpLife-Backend.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/Mappers/HabitMapper.cs
+++ b/Mappers/HabitMapper.cs
@@ -34,7 +34,6 @@ public static class HabitMapper
 
     public static void UpdateEntity(UpdateHabitRequestDto dto, Habit existingHabit)
     {
-        existingHabit.Discipline.Id = dto.DisciplineId;
         existingHabit.Title = dto.Title;
         existingHabit.Description = dto.Description;
     }

--- a/Mappers/HabitTaskMapper.cs
+++ b/Mappers/HabitTaskMapper.cs
@@ -1,3 +1,4 @@
+using LevelUpLifeBackend.DTOs.Requests;
 using LevelUpLifeBackend.DTOs.Responses;
 using LevelUpLifeBackend.Models;
 
@@ -5,6 +6,27 @@ namespace LevelUpLifeBackend.Mappers;
 
 public static class HabitTaskMapper
 {
+    public static void ApplyStandaloneRequest(
+        CreateStandaloneHabitTaskRequestDto request,
+        HabitTask task,
+        int habitDisciplineId
+    )
+    {
+        task.HabitDisciplineId = request.HabitDisciplineId ?? habitDisciplineId;
+        task.Title = request.Title.Trim();
+        task.Description = request.Description;
+        task.WeekDays = request.WeekDays;
+        task.Difficulty = request.Difficulty!.Value;
+        task.XpValue = request.XpValue ?? 0;
+        task.Frequency = request.Frequency!.Value;
+        task.PeriodLength = request.PeriodLength ?? 1;
+        task.PeriodUnit = request.PeriodUnit ?? TaskPeriodUnit.DAYS;
+        task.StartDate = request.StartDate ?? task.StartDate;
+        task.CompletionCriteria = request.CompletionCriteria!.Value;
+        task.Evidence = request.Evidence;
+        task.IsActive = request.IsActive ?? task.IsActive;
+    }
+
     public static HabitTaskResponseDto ToResponse(HabitTask task)
     {
         return new HabitTaskResponseDto

--- a/Mappers/HabitTaskMapper.cs
+++ b/Mappers/HabitTaskMapper.cs
@@ -27,6 +27,43 @@ public static class HabitTaskMapper
         task.IsActive = request.IsActive ?? task.IsActive;
     }
 
+    public static void ApplyNestedUpdateRequest(
+        UpdateHabitTaskRequestDto request,
+        HabitTask task,
+        int habitDisciplineId
+    )
+    {
+        if (request.HabitDisciplineId.HasValue)
+            task.HabitDisciplineId = request.HabitDisciplineId;
+        else if (request.Title is not null || request.Difficulty.HasValue)
+            task.HabitDisciplineId ??= habitDisciplineId;
+
+        if (request.Title is not null)
+            task.Title = request.Title.Trim();
+        if (request.Description is not null)
+            task.Description = request.Description;
+        if (request.WeekDays is not null)
+            task.WeekDays = request.WeekDays;
+        if (request.Difficulty.HasValue)
+            task.Difficulty = request.Difficulty.Value;
+        if (request.XpValue.HasValue)
+            task.XpValue = request.XpValue.Value;
+        if (request.Frequency.HasValue)
+            task.Frequency = request.Frequency.Value;
+        if (request.PeriodLength.HasValue)
+            task.PeriodLength = request.PeriodLength.Value;
+        if (request.PeriodUnit.HasValue)
+            task.PeriodUnit = request.PeriodUnit.Value;
+        if (request.StartDate.HasValue)
+            task.StartDate = request.StartDate.Value;
+        if (request.CompletionCriteria.HasValue)
+            task.CompletionCriteria = request.CompletionCriteria.Value;
+        if (request.Evidence.HasValue)
+            task.Evidence = request.Evidence;
+        if (request.IsActive.HasValue)
+            task.IsActive = request.IsActive.Value;
+    }
+
     public static HabitTask ToEntity(
         CreateHabitTaskRequestDto dto,
         int habitId,

--- a/Mappers/RepetitionCriteriaMapper.cs
+++ b/Mappers/RepetitionCriteriaMapper.cs
@@ -28,6 +28,16 @@ public static class RepetitionCriteriaMapper
             entity.StatusRepetitionsCriteriaIsActive = dto.IsActive.Value;
     }
 
+    public static void UpdateEntity(RepetitionCriteria entity, CreateRepetitionCriteriaRequestDto dto)
+    {
+        entity.NumRepetitionsObjective = dto.Repetitions ?? entity.NumRepetitionsObjective;
+        entity.TypeUnityMeasurementUnit = dto.MeasurementUnit ?? entity.TypeUnityMeasurementUnit;
+        if (dto.IsPartialAllowed.HasValue)
+            entity.StatusIsPartialAllowed = dto.IsPartialAllowed.Value;
+        if (dto.IsActive.HasValue)
+            entity.StatusRepetitionsCriteriaIsActive = dto.IsActive.Value;
+    }
+
     public static RepetitionCriteriaResponseDto ToResponse(RepetitionCriteria entity)
     {
         return new RepetitionCriteriaResponseDto

--- a/Repositories/HabitRepository.cs
+++ b/Repositories/HabitRepository.cs
@@ -60,7 +60,6 @@ public class HabitRepository : IHabitRepository
         _context.Entry(habit.Discipline).State = EntityState.Unchanged;
         _context.Entry(habit.Discipline.Category).State = EntityState.Unchanged;
         _context.Entry(habit.User).State = EntityState.Unchanged;
-        _context.Habits.Update(habit);
         await _context.SaveChangesAsync();
     }
 }

--- a/Repositories/HabitTaskRepository.cs
+++ b/Repositories/HabitTaskRepository.cs
@@ -60,11 +60,6 @@ public class HabitTaskRepository : IHabitTaskRepository
         }
     }
 
-    public Task<bool> ExistsActiveByHabitIdAsync(int habitId)
-    {
-        return _context.HabitTasks.AsNoTracking().AnyAsync(t => t.HabitId == habitId && t.IsActive);
-    }
-
     public Task<HabitTask?> GetByIdWithCriteriaAsync(int id)
     {
         return _context.HabitTasks

--- a/Repositories/HabitTaskRepository.cs
+++ b/Repositories/HabitTaskRepository.cs
@@ -36,18 +36,9 @@ public class HabitTaskRepository : IHabitTaskRepository
         await using var transaction = await _context.Database.BeginTransactionAsync();
         try
         {
-            _context.HabitTasks.Update(task);
-
-            if (task.RepetitionCriteria is not null)
+            if (task.RepetitionCriteria is not null && task.RepetitionCriteria.Id == 0)
             {
-                if (task.RepetitionCriteria.Id == 0)
-                {
-                    await _context.RepetitionCriteriaRecords.AddAsync(task.RepetitionCriteria);
-                }
-                else
-                {
-                    _context.RepetitionCriteriaRecords.Update(task.RepetitionCriteria);
-                }
+                await _context.RepetitionCriteriaRecords.AddAsync(task.RepetitionCriteria);
             }
 
             await _context.SaveChangesAsync();

--- a/Repositories/HabitTaskRepository.cs
+++ b/Repositories/HabitTaskRepository.cs
@@ -20,12 +20,6 @@ public class HabitTaskRepository : IHabitTaskRepository
         return task;
     }
 
-    public async Task UpdateAsync(HabitTask task)
-    {
-        _context.HabitTasks.Update(task);
-        await _context.SaveChangesAsync();
-    }
-
     public Task<HabitTask?> GetTrackedByIdForUserAsync(int taskId, int userId)
     {
         return _context.HabitTasks
@@ -35,6 +29,35 @@ public class HabitTaskRepository : IHabitTaskRepository
                 .ThenInclude(h => h.Discipline)
             .Include(t => t.RepetitionCriteria)
             .FirstOrDefaultAsync(t => t.Id == taskId && t.Habit!.User.Id == userId);
+    }
+
+    public async Task UpdateWithRepetitionCriteriaAsync(HabitTask task)
+    {
+        await using var transaction = await _context.Database.BeginTransactionAsync();
+        try
+        {
+            _context.HabitTasks.Update(task);
+
+            if (task.RepetitionCriteria is not null)
+            {
+                if (task.RepetitionCriteria.Id == 0)
+                {
+                    await _context.RepetitionCriteriaRecords.AddAsync(task.RepetitionCriteria);
+                }
+                else
+                {
+                    _context.RepetitionCriteriaRecords.Update(task.RepetitionCriteria);
+                }
+            }
+
+            await _context.SaveChangesAsync();
+            await transaction.CommitAsync();
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
     }
 
     public Task<bool> ExistsActiveByHabitIdAsync(int habitId)

--- a/Repositories/HabitTaskRepository.cs
+++ b/Repositories/HabitTaskRepository.cs
@@ -20,6 +20,23 @@ public class HabitTaskRepository : IHabitTaskRepository
         return task;
     }
 
+    public async Task UpdateAsync(HabitTask task)
+    {
+        _context.HabitTasks.Update(task);
+        await _context.SaveChangesAsync();
+    }
+
+    public Task<HabitTask?> GetTrackedByIdForUserAsync(int taskId, int userId)
+    {
+        return _context.HabitTasks
+            .Include(t => t.Habit!)
+                .ThenInclude(h => h.User)
+            .Include(t => t.Habit!)
+                .ThenInclude(h => h.Discipline)
+            .Include(t => t.RepetitionCriteria)
+            .FirstOrDefaultAsync(t => t.Id == taskId && t.Habit!.User.Id == userId);
+    }
+
     public Task<bool> ExistsActiveByHabitIdAsync(int habitId)
     {
         return _context.HabitTasks.AsNoTracking().AnyAsync(t => t.HabitId == habitId && t.IsActive);

--- a/Repositories/IHabitTaskRepository.cs
+++ b/Repositories/IHabitTaskRepository.cs
@@ -5,8 +5,10 @@ namespace LevelUpLifeBackend.Repositories;
 public interface IHabitTaskRepository
 {
     Task<HabitTask> AddAsync(HabitTask task);
+    Task UpdateAsync(HabitTask task);
     Task<bool> ExistsActiveByHabitIdAsync(int habitId);
     Task<HabitTask?> GetByIdWithCriteriaAsync(int id);
+    Task<HabitTask?> GetTrackedByIdForUserAsync(int taskId, int userId);
     Task<IEnumerable<EvidenceStorage>> GetEvidencesByTaskIdAsync(int taskId);
     Task<EvidenceStorage?> GetEvidenceByIdAsync(int taskId, int id);
     Task<bool> ExistsAsync(int taskId);

--- a/Repositories/IHabitTaskRepository.cs
+++ b/Repositories/IHabitTaskRepository.cs
@@ -5,10 +5,10 @@ namespace LevelUpLifeBackend.Repositories;
 public interface IHabitTaskRepository
 {
     Task<HabitTask> AddAsync(HabitTask task);
-    Task UpdateAsync(HabitTask task);
+    Task<HabitTask?> GetTrackedByIdForUserAsync(int taskId, int userId);
+    Task UpdateWithRepetitionCriteriaAsync(HabitTask task);
     Task<bool> ExistsActiveByHabitIdAsync(int habitId);
     Task<HabitTask?> GetByIdWithCriteriaAsync(int id);
-    Task<HabitTask?> GetTrackedByIdForUserAsync(int taskId, int userId);
     Task<IEnumerable<EvidenceStorage>> GetEvidencesByTaskIdAsync(int taskId);
     Task<EvidenceStorage?> GetEvidenceByIdAsync(int taskId, int id);
     Task<bool> ExistsAsync(int taskId);

--- a/Repositories/IHabitTaskRepository.cs
+++ b/Repositories/IHabitTaskRepository.cs
@@ -7,7 +7,6 @@ public interface IHabitTaskRepository
     Task<HabitTask> AddAsync(HabitTask task);
     Task<HabitTask?> GetTrackedByIdForUserAsync(int taskId, int userId);
     Task UpdateWithRepetitionCriteriaAsync(HabitTask task);
-    Task<bool> ExistsActiveByHabitIdAsync(int habitId);
     Task<HabitTask?> GetByIdWithCriteriaAsync(int id);
     Task<IEnumerable<EvidenceStorage>> GetEvidencesByTaskIdAsync(int taskId);
     Task<EvidenceStorage?> GetEvidenceByIdAsync(int taskId, int id);

--- a/Repositories/RepetitionCriteriaRepository.cs
+++ b/Repositories/RepetitionCriteriaRepository.cs
@@ -23,6 +23,7 @@ public class RepetitionCriteriaRepository : IRepetitionCriteriaRepository
     public async Task<RepetitionCriteria?> GetByTaskIdAsync(int taskId)
     {
         return await _context.RepetitionCriteriaRecords
+            .AsNoTracking()
             .FirstOrDefaultAsync(c => c.HabitTaskId == taskId);
     }
 

--- a/Repositories/RepetitionCriteriaRepository.cs
+++ b/Repositories/RepetitionCriteriaRepository.cs
@@ -28,7 +28,6 @@ public class RepetitionCriteriaRepository : IRepetitionCriteriaRepository
 
     public async Task<RepetitionCriteria> UpdateAsync(RepetitionCriteria criteria)
     {
-        _context.RepetitionCriteriaRecords.Update(criteria);
         await _context.SaveChangesAsync();
         return criteria;
     }

--- a/Services/HabitService.cs
+++ b/Services/HabitService.cs
@@ -190,42 +190,26 @@ public class HabitService : IHabitService
             );
         }
 
-        await using var transaction = await _context.Database.BeginTransactionAsync();
-        try
+        HabitTaskMapper.ApplyStandaloneRequest(request, task, task.Habit.Discipline.Id);
+
+        if (request.CompletionCriteria == TaskCompletionCriteria.REPETITIONS)
         {
-            HabitTaskMapper.ApplyStandaloneRequest(request, task, task.Habit.Discipline.Id);
-            await _habitTaskRepository.UpdateAsync(task);
-
-            RepetitionCriteria? criteria = task.RepetitionCriteria;
-            if (request.CompletionCriteria == TaskCompletionCriteria.REPETITIONS)
+            if (task.RepetitionCriteria is null)
             {
-                if (criteria is null)
-                {
-                    criteria = await _repetitionCriteriaRepository.AddAsync(
-                        RepetitionCriteriaMapper.ToEntity(task.Id, request.RepetitionCriteria!)
-                    );
-                }
-                else
-                {
-                    RepetitionCriteriaMapper.UpdateEntity(criteria, request.RepetitionCriteria!);
-                    criteria = await _repetitionCriteriaRepository.UpdateAsync(criteria);
-                }
+                task.RepetitionCriteria = RepetitionCriteriaMapper.ToEntity(
+                    task.Id,
+                    request.RepetitionCriteria!
+                );
             }
-
-            await transaction.CommitAsync();
-
-            if (criteria is not null)
+            else
             {
-                task.RepetitionCriteria = criteria;
+                RepetitionCriteriaMapper.UpdateEntity(task.RepetitionCriteria, request.RepetitionCriteria!);
             }
+        }
 
-            return HabitTaskMapper.ToResponse(task);
-        }
-        catch
-        {
-            await transaction.RollbackAsync();
-            throw;
-        }
+        await _habitTaskRepository.UpdateWithRepetitionCriteriaAsync(task);
+
+        return HabitTaskMapper.ToResponse(task);
     }
 
     public async Task<HabitResponseDto?> GetByIdAsync(int id, int userId)

--- a/Services/HabitService.cs
+++ b/Services/HabitService.cs
@@ -189,6 +189,88 @@ public class HabitService : IHabitService
         }
     }
 
+    public async Task<HabitTaskResponseDto> UpdateTaskAsync(
+        int taskId,
+        CreateStandaloneHabitTaskRequestDto request,
+        int userId
+    )
+    {
+        var task = await _habitTaskRepository.GetTrackedByIdForUserAsync(taskId, userId);
+        if (task is null || task.Habit is null)
+        {
+            throw new NotFoundError(
+                new ErrorResponse
+                {
+                    Code = 404,
+                    Message = "Task not found",
+                    Details = $"Habit task with id {taskId} was not found for the authenticated user.",
+                }
+            );
+        }
+
+        if (task.HabitId != request.HabitId)
+        {
+            throw new AppError(
+                400,
+                new ErrorResponse
+                {
+                    Code = 400,
+                    Message = "Validation failed",
+                    Details = "HabitId in the request body must match the task's habit.",
+                }
+            );
+        }
+
+        if (!task.Habit.IsActive)
+        {
+            throw new NotFoundError(
+                new ErrorResponse
+                {
+                    Code = 404,
+                    Message = "Habit not found",
+                    Details = $"Habit with id {request.HabitId} does not exist or is inactive.",
+                }
+            );
+        }
+
+        await using var transaction = await _context.Database.BeginTransactionAsync();
+        try
+        {
+            HabitTaskMapper.ApplyStandaloneRequest(request, task, task.Habit.Discipline.Id);
+            await _habitTaskRepository.UpdateAsync(task);
+
+            RepetitionCriteria? criteria = task.RepetitionCriteria;
+            if (request.CompletionCriteria == TaskCompletionCriteria.REPETITIONS)
+            {
+                if (criteria is null)
+                {
+                    criteria = await _repetitionCriteriaRepository.AddAsync(
+                        RepetitionCriteriaMapper.ToEntity(task.Id, request.RepetitionCriteria!)
+                    );
+                }
+                else
+                {
+                    RepetitionCriteriaMapper.UpdateEntity(criteria, request.RepetitionCriteria!);
+                    criteria = await _repetitionCriteriaRepository.UpdateAsync(criteria);
+                }
+            }
+
+            await transaction.CommitAsync();
+
+            if (criteria is not null)
+            {
+                task.RepetitionCriteria = criteria;
+            }
+
+            return HabitTaskMapper.ToResponse(task);
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+    }
+
     public async Task<HabitResponseDto?> GetByIdAsync(int id)
     {
         var habit = await _habitRepository.GetByIdAsync(id);

--- a/Services/HabitService.cs
+++ b/Services/HabitService.cs
@@ -87,18 +87,6 @@ public class HabitService : IHabitService
             );
         }
 
-        if (await _habitTaskRepository.ExistsActiveByHabitIdAsync(request.HabitId))
-        {
-            throw new ConflictError(
-                new ErrorResponse
-                {
-                    Code = 409,
-                    Message = "TASK_ALREADY_EXISTS",
-                    Details = $"Habit {request.HabitId} already has an active task.",
-                }
-            );
-        }
-
         await using var transaction = await _context.Database.BeginTransactionAsync();
         try
         {

--- a/Services/HabitService.cs
+++ b/Services/HabitService.cs
@@ -253,21 +253,33 @@ public class HabitService : IHabitService
         try
         {
             HabitMapper.UpdateEntity(dto, existingHabit);
-            await _habitRepository.UpdateHabitAsync(existingHabit);
+            _context.Entry(existingHabit).Property("DisciplineId").CurrentValue = dto.DisciplineId;
 
             if (dto.Tasks is not null)
             {
                 foreach (var taskDto in dto.Tasks)
                 {
-                    if (taskDto.RepetitionCriteria is null) continue;
+                    var task = existingHabit.Tasks.FirstOrDefault(t => t.Id == taskDto.TaskId);
+                    if (task is null) continue;
 
-                    var criteria = await _repetitionCriteriaRepository.GetByTaskIdAsync(taskDto.TaskId);
-                    if (criteria is null) continue;
+                    HabitTaskMapper.ApplyNestedUpdateRequest(
+                        taskDto,
+                        task,
+                        existingHabit.Discipline.Id
+                    );
 
-                    RepetitionCriteriaMapper.UpdateEntity(criteria, taskDto.RepetitionCriteria);
-                    await _repetitionCriteriaRepository.UpdateAsync(criteria);
+                    if (taskDto.RepetitionCriteria is not null)
+                    {
+                        var criteria = await _repetitionCriteriaRepository.GetByTaskIdAsync(taskDto.TaskId);
+                        if (criteria is not null)
+                        {
+                            RepetitionCriteriaMapper.UpdateEntity(criteria, taskDto.RepetitionCriteria);
+                        }
+                    }
                 }
             }
+
+            await _habitRepository.UpdateHabitAsync(existingHabit);
 
             await transaction.CommitAsync();
 

--- a/Services/HabitService.cs
+++ b/Services/HabitService.cs
@@ -246,6 +246,7 @@ public class HabitService : IHabitService
             .Include(h => h.Discipline).ThenInclude(d => d.Category)
             .Include(h => h.User)
             .Include(h => h.Tasks)
+                .ThenInclude(t => t.RepetitionCriteria)
             .FirstOrDefaultAsync(h => h.Id == dto.Id);
         if (existingHabit is null) return null;
 
@@ -253,7 +254,6 @@ public class HabitService : IHabitService
         try
         {
             HabitMapper.UpdateEntity(dto, existingHabit);
-            _context.Entry(existingHabit).Property("DisciplineId").CurrentValue = dto.DisciplineId;
 
             if (dto.Tasks is not null)
             {
@@ -278,6 +278,8 @@ public class HabitService : IHabitService
                     }
                 }
             }
+
+            _context.Entry(existingHabit).Property("DisciplineId").CurrentValue = dto.DisciplineId;
 
             await _habitRepository.UpdateHabitAsync(existingHabit);
 

--- a/Services/IHabitService.cs
+++ b/Services/IHabitService.cs
@@ -7,6 +7,11 @@ public interface IHabitService
 {
     Task<HabitResponseDto> CreateAsync(CreateHabitRequestDto request);
     Task<HabitTaskResponseDto> CreateTaskAsync(CreateStandaloneHabitTaskRequestDto request, int userId);
+    Task<HabitTaskResponseDto> UpdateTaskAsync(
+        int taskId,
+        CreateStandaloneHabitTaskRequestDto request,
+        int userId
+    );
     Task<HabitResponseDto?> GetByIdAsync(int id);
     Task<PagedResultDto<HabitResponseDto>> GetActiveHabitsPaginatedAsync(
         int pageNumber,


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

This PR implements **Update Habit Task** (`PUT /api/habit-tasks/{id}`) for issue **#27**.

Changes include:
- `PUT` endpoint in `HabitTaskController` with JWT / `X-User-Id` authentication
- `UpdateTaskAsync` in `HabitService` (ownership validation, active habit check, transaction)
- `GetTrackedByIdForUserAsync` and `UpdateAsync` in `HabitTaskRepository`
- `ApplyStandaloneRequest` in `HabitTaskMapper` and `UpdateEntity` overload in `RepetitionCriteriaMapper`
- Unit tests in `HabitServiceUpdateTaskTests`

The branch is based on `dev` and includes the approved changes from PR #71 (issue #24).

---

## 🎯 Purpose

Users need to update an existing habit task (title, schedule, completion criteria, repetition criteria, etc.) without creating a new one.

This change exposes a REST endpoint aligned with the existing `POST /api/habit-tasks` contract, enforcing that only the habit owner can update their tasks.

---

## 🔄 Type of Change

Please check the relevant option:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

Describe the tests you ran and how you verified your changes.

- [x] Manual testing (Scalar / OpenAPI)
- [x] Unit tests
- [ ] Integration tests

**Testing process:**
1. Start PostgreSQL (`leveluplife-postgres` on port `5433`) and run the API (`dotnet run --launch-profile http`).
2. Log in and obtain a JWT (user `aarondev` or equivalent).
3. Identify a **habit task ID** that belongs to the authenticated user (e.g. via `GET /api/Habits/{id}` from issue #24).
4. Execute each scenario in the evidence table below in Scalar.
5. Run unit tests: `dotnet test` (project `LevelUpLife-Backend.Tests`).

**Sample request (200 OK):**
- **Method:** `PUT`
- **URL:** `http://localhost:5223/api/habit-tasks/{taskId}`
- **Headers:** `Authorization: Bearer <token>` (or `X-User-Id: <userId>`)
- **Body:**

```json
{
  "habitId": 1,
  "title": "Updated morning run",
  "description": "Updated description",
  "difficulty": 2,
  "frequency": 1,
  "periodLength": 1,
  "periodUnit": 0,
  "startDate": "2026-05-28",
  "completionCriteria": 1,
  "xpValue": 50,
  "isActive": true,
  "repetitionCriteria": {
    "repetitions": 5,
    "measurementUnit": 0,
    "isPartialAllowed": true
  }
}
```

> Replace `{taskId}` and `habitId` with real IDs from your database. `habitId` in the body must match the task’s habit.

---

## 📸 Screenshots (if applicable)

### Evidence table (QA)

| # | Scenario | Request | Expected HTTP | Expected response (summary) | Screenshot |
|---|----------|---------|---------------|-----------------------------|------------|
| 1 | Successful update | `PUT /api/habit-tasks/{id}` with valid JWT and body (`habitId` matches task) | **200** | Updated task DTO (`title`, `difficulty`, `repetitionCriteria`, etc.) |<img width="1383" height="830" alt="image" src="https://github.com/user-attachments/assets/d6db034f-6b30-437c-bc29-68fb958658b6" />|
| 2 | Unauthorized | `PUT` without `Authorization` and without `X-User-Id` | **401** | `code: UNAUTHORIZED` |<img width="1389" height="831" alt="image" src="https://github.com/user-attachments/assets/05e791af-590a-4cf6-9e77-42316414faab" />|
| 3 | Task not found | `PUT /api/habit-tasks/99999` (non-existent ID) | **404** | `code: TASK_NOT_FOUND` |<img width="1381" height="827" alt="image" src="https://github.com/user-attachments/assets/49d592a7-df32-444c-91c2-53690ef915dc" />|
| 4 | Task not owned by user | `PUT` with valid token of user A on task owned by user B | **404** | `code: TASK_NOT_FOUND` (no leak of other user’s data) |<img width="1387" height="827" alt="image" src="https://github.com/user-attachments/assets/c7b71022-5d6d-4bda-8f85-ba932e3c2e6a" />|
| 5 | HabitId mismatch | `PUT` with `habitId` in body ≠ task’s real `habitId` | **400** | `code: VALIDATION_ERROR`, details about `HabitId` |<img width="1389" height="835" alt="image" src="https://github.com/user-attachments/assets/369d8a49-2b84-43fe-9fe4-4e02d5b8a255" />|
| 6 | Invalid body | `PUT` with missing `title` or invalid `completionCriteria` | **400** | Validation error (`ValidationProblem` or `VALIDATION_ERROR`) |<img width="1382" height="826" alt="image" src="https://github.com/user-attachments/assets/26274ae2-9ed8-40fe-8c2f-83294aec73ef" />|
| 87| Unit tests | `dotnet test --filter HabitServiceUpdateTaskTests` | **Pass** | 3 tests green |<img width="880" height="144" alt="image" src="https://github.com/user-attachments/assets/38a15d16-5132-4997-822a-ca1c583c2f8f" />|

> **Note for QA:** Paste screenshots into the PR or upload to `evidence/` and update image paths. Empty cells can use `_(pending)_` until captured.

---

## 🚀 Deployment Notes (if needed)

- No new migrations required for this feature (uses existing schema).
- Requires PostgreSQL connection configured in `appsettings.Development.json` (not committed).
- No new environment variables beyond existing JWT configuration.

---

## ✅ Checklist

Before requesting a review, please confirm:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #27  
Linked to #24

---