### PR TITLE
25 get habit task detail

### DIFF
--- a/Controllers/HabitTaskController.cs
+++ b/Controllers/HabitTaskController.cs
@@ -162,6 +162,33 @@ public class HabitTaskController : ControllerBase
         }
     }
 
+    [HttpGet("{taskId:int}")]
+    public async Task<IActionResult> GetById(int taskId)
+    {
+        try
+        {
+            var task = await _habitTaskService.GetByIdAsync(taskId);
+            return Ok(task);
+        }
+        catch (NotFoundError ex)
+        {
+            return NotFound(ex.Payload);
+        }
+        catch (ServerError ex)
+        {
+            return StatusCode(ex.HttpStatusCode, ex.Payload);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new ErrorResponse
+            {
+                Code = 500,
+                Message = "An unexpected error occurred.",
+                Details = ex.Message
+            });
+        }
+    }
+
     [HttpGet("{taskId:int}/evidences")]
     public async Task<IActionResult> GetEvidences(int taskId)
     {

--- a/DTOs/Responses/HabitTaskResponseDto.cs
+++ b/DTOs/Responses/HabitTaskResponseDto.cs
@@ -6,7 +6,7 @@ public class HabitTaskResponseDto
 {
     public int Id { get; set; }
     public int HabitId { get; set; }
-    public int? HabitDisciplineId { get; set; }
+    public HabitDisciplineDetailResponseDto? HabitDiscipline { get; set; }
     public string Title { get; set; } = string.Empty;
     public string? Description { get; set; }
     public int XpValue { get; set; }

--- a/Mappers/HabitTaskMapper.cs
+++ b/Mappers/HabitTaskMapper.cs
@@ -121,7 +121,14 @@ public static class HabitTaskMapper
         {
             Id = task.Id,
             HabitId = task.HabitId,
-            HabitDisciplineId = task.HabitDisciplineId,
+            HabitDiscipline = task.HabitDiscipline is null ? null : new HabitDisciplineDetailResponseDto
+            {
+                IdHabitDiscipline = task.HabitDiscipline.Id,
+                IdHabitCategory = task.HabitDiscipline.Category.Id,
+                DscHabitDisciplineName = task.HabitDiscipline.Name,
+                DscHabitDisciplineDescription = task.HabitDiscipline.Description,
+                StatusHabitDisciplineIsActive = task.HabitDiscipline.IsActive,
+            },
             Title = task.Title,
             Description = task.Description,
             XpValue = task.XpValue,

--- a/Repositories/HabitTaskRepository.cs
+++ b/Repositories/HabitTaskRepository.cs
@@ -56,6 +56,8 @@ public class HabitTaskRepository : IHabitTaskRepository
         return _context.HabitTasks
             .AsNoTracking()
             .Include(t => t.RepetitionCriteria)
+            .Include(t => t.HabitDiscipline)
+                .ThenInclude(d => d!.Category)
             .FirstOrDefaultAsync(t => t.Id == id);
     }
 

--- a/Services/HabitTaskService.cs
+++ b/Services/HabitTaskService.cs
@@ -1,5 +1,6 @@
 using LevelUpLifeBackend.DTOs.Responses;
 using LevelUpLifeBackend.Infrastructure.Errors;
+using LevelUpLifeBackend.Mappers;
 using LevelUpLifeBackend.Repositories;
 
 namespace LevelUpLifeBackend.Services;
@@ -11,6 +12,39 @@ public class HabitTaskService : IHabitTaskService
     public HabitTaskService(IHabitTaskRepository habitTaskRepository)
     {
         _habitTaskRepository = habitTaskRepository;
+    }
+
+    public async Task<HabitTaskResponseDto> GetByIdAsync(int taskId)
+    {
+        try
+        {
+            var task = await _habitTaskRepository.GetByIdWithCriteriaAsync(taskId);
+
+            if (task is null)
+            {
+                throw new NotFoundError(new ErrorResponse
+                {
+                    Code = 404,
+                    Message = $"Task with ID {taskId} not found.",
+                    Details = "The requested habit task does not exist in the database."
+                });
+            }
+
+            return HabitTaskMapper.ToResponse(task);
+        }
+        catch (NotFoundError)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new ServerError(500, new ErrorResponse
+            {
+                Code = 500,
+                Message = "An unexpected error occurred while fetching the habit task.",
+                Details = ex.Message
+            });
+        }
     }
 
     public async Task<IEnumerable<EvidenceStorageResponseDto>> GetEvidencesByTaskIdAsync(int taskId)

--- a/Services/IHabitTaskService.cs
+++ b/Services/IHabitTaskService.cs
@@ -4,6 +4,7 @@ namespace LevelUpLifeBackend.Services;
 
 public interface IHabitTaskService
 {
+    Task<HabitTaskResponseDto> GetByIdAsync(int taskId);
     Task<IEnumerable<EvidenceStorageResponseDto>> GetEvidencesByTaskIdAsync(int taskId);
     Task<EvidenceStorageResponseDto> GetEvidenceByIdAsync(int taskId, int id);
 }


### PR DESCRIPTION
📖 Description

  This PR implements the Get Habit Task Detail by ID endpoint (GET /api/habit-tasks/{taskId}), which returns the full details of a habit task
  including its nested discipline object. Changes span the entire request pipeline: repository, DTO, mapper, service interface, service
  implementation, and controller.

  ---
  🎯 Purpose

  Previously there was no dedicated endpoint to fetch the details of a single habit task by its ID. This was required as part of issue #25 to allow
  clients to retrieve complete task information, including the associated discipline, without relying on the full habit detail endpoint.

  ---
  🔄 Type of Change

  - [x] ✨ New feature

  ---
  🧪 How Has This Been Tested?

  - [x] Manual testing

  The endpoint was tested manually by sending a GET request to /api/habit-tasks/{taskId} with a valid task ID, verifying that:
  - The response includes all task fields correctly.
  - The habitDiscipline object is populated with the discipline's ID, category ID, name, description, and active status.
  - The repetitionCriteria object is populated when the task's completion criteria is REPETITIONS, and null otherwise.
  - A 404 is returned when the task ID does not exist.

  ---
  📸 Screenshots (if applicable)

<img width="1413" height="816" alt="image" src="https://github.com/user-attachments/assets/34162fa6-34f3-4b30-b902-4304a3b25441" />

  ---
  ---
  🚀 Deployment Notes (if needed)

  No special deployment steps required. No migrations were added.

  ---
  ✅ Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have tested my changes thoroughly
  - [x] I have updated documentation if necessary
  - [x] My changes do not introduce new warnings or errors

  ---
  🧩 Related Issues

  Closes #25
