### PR TITLE
21 create habit discipline

### DIFF
--- a/Controllers/HabitDisciplineApiController.cs
+++ b/Controllers/HabitDisciplineApiController.cs
@@ -1,6 +1,9 @@
+using LevelUpLifeBackend.DTOs.Requests;
 using LevelUpLifeBackend.Infrastructure.Errors;
 using LevelUpLifeBackend.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace LevelUpLifeBackend.Controllers;
 
@@ -26,6 +29,44 @@ public class HabitDisciplineApiController : ControllerBase
         catch (NotFoundError ex)
         {
             return NotFound(ex.Payload);
+        }
+        catch (ServerError ex)
+        {
+            return StatusCode(ex.HttpStatusCode, ex.Payload);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(
+                500,
+                new ErrorResponse
+                {
+                    Code = 500,
+                    Message = "An unexpected error occurred.",
+                    Details = ex.Message,
+                }
+            );
+        }
+    }
+
+    [Authorize]
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateHabitDisciplineRequestDto request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var created = await _habitDisciplineService.CreateDisciplineAsync(request);
+            return CreatedAtAction(nameof(GetById), new { id = created.IdHabitDiscipline }, created);
+        }
+        catch (AppError ex) when (ex.HttpStatusCode == StatusCodes.Status400BadRequest)
+        {
+            var modelState = new ModelStateDictionary();
+            modelState.AddModelError("idHabitCategory", ex.Payload.Details ?? ex.Payload.Message);
+            return ValidationProblem(modelState);
         }
         catch (ServerError ex)
         {

--- a/DTOs/Requests/CreateHabitDisciplineRequestDto.cs
+++ b/DTOs/Requests/CreateHabitDisciplineRequestDto.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace LevelUpLifeBackend.DTOs.Requests;
+
+public class CreateHabitDisciplineRequestDto
+{
+    [Required(ErrorMessage = "idHabitCategory is required.")]
+    [Range(1, int.MaxValue, ErrorMessage = "idHabitCategory must be greater than 0.")]
+    [JsonPropertyName("idHabitCategory")]
+    [Display(Name = "idHabitCategory")]
+    public int IdHabitCategory { get; set; }
+
+    [Required(ErrorMessage = "dscHabitDisciplineName is required.")]
+    [StringLength(50, MinimumLength = 1, ErrorMessage = "dscHabitDisciplineName must be between 1 and 50 characters.")]
+    [JsonPropertyName("dscHabitDisciplineName")]
+    [Display(Name = "dscHabitDisciplineName")]
+    public string DscHabitDisciplineName { get; set; } = string.Empty;
+
+    [JsonPropertyName("dscHabitDisciplineDescription")]
+    [Display(Name = "dscHabitDisciplineDescription")]
+    public string? DscHabitDisciplineDescription { get; set; }
+
+    [JsonPropertyName("statusHabitDisciplineIsActive")]
+    [Display(Name = "statusHabitDisciplineIsActive")]
+    public bool StatusHabitDisciplineIsActive { get; set; } = true;
+}

--- a/LevelUpLife-Backend.Tests/HabitDisciplineServiceTests.cs
+++ b/LevelUpLife-Backend.Tests/HabitDisciplineServiceTests.cs
@@ -1,3 +1,4 @@
+using LevelUpLifeBackend.DTOs.Requests;
 using LevelUpLifeBackend.Infrastructure.Errors;
 using LevelUpLifeBackend.Models;
 using LevelUpLifeBackend.Repositories;
@@ -10,12 +11,16 @@ namespace LevelUpLife_Backend.Tests;
 public class HabitDisciplineServiceTests
 {
     private readonly Mock<IHabitDisciplineRepository> _repositoryMock;
+    private readonly Mock<IHabitCategoryRepository> _categoryRepositoryMock;
     private readonly HabitDisciplineService _service;
 
     public HabitDisciplineServiceTests()
     {
         _repositoryMock = new Mock<IHabitDisciplineRepository>();
-        _service = new HabitDisciplineService(_repositoryMock.Object);
+        _categoryRepositoryMock = new Mock<IHabitCategoryRepository>();
+        _service = new HabitDisciplineService(
+            _repositoryMock.Object,
+            _categoryRepositoryMock.Object);
     }
 
     [Fact]
@@ -61,5 +66,50 @@ public class HabitDisciplineServiceTests
         var exception = await Assert.ThrowsAsync<ServerError>(() => _service.GetDisciplineByIdAsync(1));
 
         Assert.Equal(500, exception.HttpStatusCode);
+    }
+
+    [Fact]
+    public async Task CreateDisciplineAsync_WhenCategoryExists_ReturnsCreatedDto()
+    {
+        var request = new CreateHabitDisciplineRequestDto
+        {
+            IdHabitCategory = 2,
+            DscHabitDisciplineName = "Meditation",
+            DscHabitDisciplineDescription = "Daily mindfulness practice",
+            StatusHabitDisciplineIsActive = true,
+        };
+
+        _categoryRepositoryMock.Setup(r => r.GetByIdAsync(2)).ReturnsAsync(new HabitCategory { Id = 2 });
+        _repositoryMock
+            .Setup(r => r.AddAsync(It.IsAny<HabitDiscipline>()))
+            .ReturnsAsync((HabitDiscipline discipline) =>
+            {
+                discipline.Id = 15;
+                return discipline;
+            });
+
+        var result = await _service.CreateDisciplineAsync(request);
+
+        Assert.Equal(15, result.IdHabitDiscipline);
+        Assert.Equal(2, result.IdHabitCategory);
+        Assert.Equal("Meditation", result.DscHabitDisciplineName);
+        Assert.Equal("Daily mindfulness practice", result.DscHabitDisciplineDescription);
+        Assert.True(result.StatusHabitDisciplineIsActive);
+    }
+
+    [Fact]
+    public async Task CreateDisciplineAsync_WhenCategoryDoesNotExist_ThrowsAppError400()
+    {
+        var request = new CreateHabitDisciplineRequestDto
+        {
+            IdHabitCategory = 999,
+            DscHabitDisciplineName = "Meditation",
+        };
+
+        _categoryRepositoryMock.Setup(r => r.GetByIdAsync(999)).ReturnsAsync((HabitCategory?)null);
+
+        var exception = await Assert.ThrowsAsync<AppError>(() => _service.CreateDisciplineAsync(request));
+
+        Assert.Equal(400, exception.HttpStatusCode);
     }
 }

--- a/Repositories/HabitCategoryRepository.cs
+++ b/Repositories/HabitCategoryRepository.cs
@@ -13,6 +13,13 @@ public class HabitCategoryRepository : IHabitCategoryRepository
         _context = context;
     }
 
+    public async Task<HabitCategory?> GetByIdAsync(int id)
+    {
+        return await _context.HabitCategories
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == id);
+    }
+
     public async Task<(
         IEnumerable<HabitCategory> HabitCategories,
         int TotalCount

--- a/Repositories/HabitDisciplineRepository.cs
+++ b/Repositories/HabitDisciplineRepository.cs
@@ -20,4 +20,12 @@ public class HabitDisciplineRepository : IHabitDisciplineRepository
             .Include(d => d.Category)
             .FirstOrDefaultAsync(d => d.Id == id);
     }
+
+    public async Task<HabitDiscipline> AddAsync(HabitDiscipline discipline)
+    {
+        _context.Entry(discipline.Category).State = EntityState.Unchanged;
+        await _context.Disciplines.AddAsync(discipline);
+        await _context.SaveChangesAsync();
+        return discipline;
+    }
 }

--- a/Repositories/IHabitCategoryRepository.cs
+++ b/Repositories/IHabitCategoryRepository.cs
@@ -4,6 +4,8 @@ namespace LevelUpLifeBackend.Repositories;
 
 public interface IHabitCategoryRepository
 {
+    Task<HabitCategory?> GetByIdAsync(int id);
+
     Task<(
         IEnumerable<HabitCategory> HabitCategories,
         int TotalCount

--- a/Repositories/IHabitDisciplineRepository.cs
+++ b/Repositories/IHabitDisciplineRepository.cs
@@ -5,4 +5,6 @@ namespace LevelUpLifeBackend.Repositories;
 public interface IHabitDisciplineRepository
 {
     Task<HabitDiscipline?> GetByIdAsync(int id);
+
+    Task<HabitDiscipline> AddAsync(HabitDiscipline discipline);
 }

--- a/Services/HabitDisciplineService.cs
+++ b/Services/HabitDisciplineService.cs
@@ -1,5 +1,7 @@
+using LevelUpLifeBackend.DTOs.Requests;
 using LevelUpLifeBackend.DTOs.Responses;
 using LevelUpLifeBackend.Infrastructure.Errors;
+using LevelUpLifeBackend.Models;
 using LevelUpLifeBackend.Repositories;
 
 namespace LevelUpLifeBackend.Services;
@@ -7,10 +9,14 @@ namespace LevelUpLifeBackend.Services;
 public class HabitDisciplineService : IHabitDisciplineService
 {
     private readonly IHabitDisciplineRepository _habitDisciplineRepository;
+    private readonly IHabitCategoryRepository _habitCategoryRepository;
 
-    public HabitDisciplineService(IHabitDisciplineRepository habitDisciplineRepository)
+    public HabitDisciplineService(
+        IHabitDisciplineRepository habitDisciplineRepository,
+        IHabitCategoryRepository habitCategoryRepository)
     {
         _habitDisciplineRepository = habitDisciplineRepository;
+        _habitCategoryRepository = habitCategoryRepository;
     }
 
     public async Task<HabitDisciplineDetailResponseDto> GetDisciplineByIdAsync(int id)
@@ -52,6 +58,62 @@ public class HabitDisciplineService : IHabitDisciplineService
                 {
                     Code = 500,
                     Message = "An unexpected error occurred while fetching the habit discipline.",
+                    Details = ex.Message,
+                }
+            );
+        }
+    }
+
+    public async Task<HabitDisciplineDetailResponseDto> CreateDisciplineAsync(
+        CreateHabitDisciplineRequestDto request)
+    {
+        try
+        {
+            var category = await _habitCategoryRepository.GetByIdAsync(request.IdHabitCategory);
+            if (category is null)
+            {
+                throw new AppError(
+                    StatusCodes.Status400BadRequest,
+                    new ErrorResponse
+                    {
+                        Code = 400,
+                        Message = "Validation failed.",
+                        Details = "The specified habit category does not exist.",
+                    }
+                );
+            }
+
+            var discipline = new HabitDiscipline
+            {
+                Category = new HabitCategory { Id = request.IdHabitCategory },
+                Name = request.DscHabitDisciplineName.Trim(),
+                Description = request.DscHabitDisciplineDescription?.Trim() ?? string.Empty,
+                IsActive = request.StatusHabitDisciplineIsActive,
+            };
+
+            var created = await _habitDisciplineRepository.AddAsync(discipline);
+
+            return new HabitDisciplineDetailResponseDto
+            {
+                IdHabitDiscipline = created.Id,
+                IdHabitCategory = request.IdHabitCategory,
+                DscHabitDisciplineName = created.Name,
+                DscHabitDisciplineDescription = created.Description,
+                StatusHabitDisciplineIsActive = created.IsActive,
+            };
+        }
+        catch (AppError)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new ServerError(
+                500,
+                new ErrorResponse
+                {
+                    Code = 500,
+                    Message = "An unexpected error occurred while creating the habit discipline.",
                     Details = ex.Message,
                 }
             );

--- a/Services/IHabitDisciplineService.cs
+++ b/Services/IHabitDisciplineService.cs
@@ -1,3 +1,4 @@
+using LevelUpLifeBackend.DTOs.Requests;
 using LevelUpLifeBackend.DTOs.Responses;
 
 namespace LevelUpLifeBackend.Services;
@@ -5,4 +6,6 @@ namespace LevelUpLifeBackend.Services;
 public interface IHabitDisciplineService
 {
     Task<HabitDisciplineDetailResponseDto> GetDisciplineByIdAsync(int id);
+
+    Task<HabitDisciplineDetailResponseDto> CreateDisciplineAsync(CreateHabitDisciplineRequestDto request);
 }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

Adds `POST /api/habit/disciplines` to create a new habit discipline linked to an existing category. The endpoint accepts `idHabitCategory`, `dscHabitDisciplineName`, `dscHabitDisciplineDescription`, and `statusHabitDisciplineIsActive`, validates the request body, verifies that the category exists, persists the discipline, and returns the created `HabitDiscipline` model on success.

---

## 🎯 Purpose

The backend needed an endpoint to create habit disciplines from the catalog layer. This change allows clients to register new disciplines under an existing category while enforcing field-level validation and authentication for write operations.

---

## 🔄 Type of Change

Please check the relevant option:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

Describe the tests you ran and how you verified your changes.

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests

Explain the testing process:

- Added unit tests in `HabitDisciplineServiceTests` for successful creation and invalid category (`AppError` 400).
- Ran `dotnet test` on `LevelUpLife-Backend.Tests` — all 22 tests passed.
- Manual verification with `curl`:
  - `POST /api/habit/disciplines` with valid body + JWT → `201` with `HabitDisciplineDetailResponseDto`
  - Invalid body (empty name, `idHabitCategory: 0`, non-existent category) → `400` with field-level `ValidationProblem` errors
  - Request without `Authorization` header or with invalid token → `401` handled by global JWT middleware (`[Authorize]`)

---

## 📸 Screenshots (if applicable)

### Login and dave token{
<img width="1485" height="438" alt="image" src="https://github.com/user-attachments/assets/420b0da2-1c2d-4e2b-b0a5-3a08ac9189b5" />

### Get active categorys
<img width="1225" height="154" alt="image" src="https://github.com/user-attachments/assets/f08ca399-97b7-44db-9496-8ae205094b5e" />

### Create new discipline
<img width="1600" height="401" alt="image" src="https://github.com/user-attachments/assets/67f2bc96-b7d6-4caa-b0a6-78e59f76298a" />

### Return 400 cases
<img width="976" height="922" alt="image" src="https://github.com/user-attachments/assets/8a2acd81-716b-462d-a37b-5fa42531c587" />

### Return 401 cases
<img width="976" height="922" alt="image" src="https://github.com/user-attachments/assets/f95b816b-e518-4aca-93ca-71121af3f11b" />


---

## 🚀 Deployment Notes (if needed)

No special deployment steps required. No new migrations were added; the endpoint uses existing tables `LULM_HABIT_CATEGORY` and `LULM_HABIT_DISCIPLINE`.

---

## ✅ Checklist

Before requesting a review, please confirm:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes 21
Linked to 21

---

### Files changed

| Layer | File | Change |
|---|---|---|
| DTO | `DTOs/Requests/CreateHabitDisciplineRequestDto.cs` | New request DTO with validation attributes |
| Repository | `Repositories/IHabitCategoryRepository.cs`, `HabitCategoryRepository.cs` | Added `GetByIdAsync` |
| Repository | `Repositories/IHabitDisciplineRepository.cs`, `HabitDisciplineRepository.cs` | Added `AddAsync` |
| Service | `Services/IHabitDisciplineService.cs`, `HabitDisciplineService.cs` | Added `CreateDisciplineAsync` |
| Controller | `Controllers/HabitDisciplineApiController.cs` | Added `[HttpPost]` with `[Authorize]` |
| Tests | `LevelUpLife-Backend.Tests/HabitDisciplineServiceTests.cs` | Added create success and invalid category tests |
