### PR TITLE
feat(evidences): add POST /habit-tasks/{taskId}/evidences endpoint

### DIFF
--- a/Controllers/HabitTaskController.cs
+++ b/Controllers/HabitTaskController.cs
@@ -189,6 +189,38 @@ public class HabitTaskController : ControllerBase
         }
     }
 
+    [HttpPost("{taskId:int}/evidences")]
+    public async Task<IActionResult> CreateEvidence(int taskId, [FromBody] CreateEvidenceRequestDto request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var created = await _habitTaskService.CreateEvidenceAsync(taskId, request);
+            return StatusCode(StatusCodes.Status201Created, created);
+        }
+        catch (NotFoundError ex)
+        {
+            return NotFound(ex.Payload);
+        }
+        catch (ServerError ex)
+        {
+            return StatusCode(ex.HttpStatusCode, ex.Payload);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new ErrorResponse
+            {
+                Code = 500,
+                Message = "An unexpected error occurred.",
+                Details = ex.Message
+            });
+        }
+    }
+
     [HttpGet("{taskId:int}/evidences")]
     public async Task<IActionResult> GetEvidences(int taskId)
     {

--- a/DTOs/Requests/CreateEvidenceRequestDto.cs
+++ b/DTOs/Requests/CreateEvidenceRequestDto.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace LevelUpLifeBackend.DTOs.Requests;
+
+public class CreateEvidenceRequestDto : IValidatableObject
+{
+    [JsonPropertyName("DSC_EVIDENCE_PATH_URL")]
+    public string? EvidencePathUrl { get; set; }
+
+    [JsonPropertyName("DSC_HEALTH_DATA_JSON")]
+    public string? HealthDataJson { get; set; }
+
+    [Required(ErrorMessage = "FEC_UPLOADED is required.")]
+    [JsonPropertyName("FEC_UPLOADED")]
+    public DateTime? UploadedAt { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (string.IsNullOrWhiteSpace(EvidencePathUrl) && string.IsNullOrWhiteSpace(HealthDataJson))
+        {
+            yield return new ValidationResult(
+                "Either DSC_EVIDENCE_PATH_URL or DSC_HEALTH_DATA_JSON must be provided.",
+                [nameof(EvidencePathUrl), nameof(HealthDataJson)]
+            );
+        }
+    }
+}

--- a/Repositories/HabitTaskRepository.cs
+++ b/Repositories/HabitTaskRepository.cs
@@ -61,6 +61,13 @@ public class HabitTaskRepository : IHabitTaskRepository
             .FirstOrDefaultAsync(t => t.Id == id);
     }
 
+    public async Task<EvidenceStorage> AddEvidenceAsync(EvidenceStorage evidence)
+    {
+        await _context.EvidenceStorages.AddAsync(evidence);
+        await _context.SaveChangesAsync();
+        return evidence;
+    }
+
     public async Task<IEnumerable<EvidenceStorage>> GetEvidencesByTaskIdAsync(int taskId)
     {
         return await _context.EvidenceStorages

--- a/Repositories/IHabitTaskRepository.cs
+++ b/Repositories/IHabitTaskRepository.cs
@@ -8,6 +8,7 @@ public interface IHabitTaskRepository
     Task<HabitTask?> GetTrackedByIdForUserAsync(int taskId, int userId);
     Task UpdateWithRepetitionCriteriaAsync(HabitTask task);
     Task<HabitTask?> GetByIdWithCriteriaAsync(int id);
+    Task<EvidenceStorage> AddEvidenceAsync(EvidenceStorage evidence);
     Task<IEnumerable<EvidenceStorage>> GetEvidencesByTaskIdAsync(int taskId);
     Task<EvidenceStorage?> GetEvidenceByIdAsync(int taskId, int id);
     Task<bool> ExistsAsync(int taskId);

--- a/Services/HabitTaskService.cs
+++ b/Services/HabitTaskService.cs
@@ -1,6 +1,8 @@
+using LevelUpLifeBackend.DTOs.Requests;
 using LevelUpLifeBackend.DTOs.Responses;
 using LevelUpLifeBackend.Infrastructure.Errors;
 using LevelUpLifeBackend.Mappers;
+using LevelUpLifeBackend.Models;
 using LevelUpLifeBackend.Repositories;
 
 namespace LevelUpLifeBackend.Services;
@@ -42,6 +44,54 @@ public class HabitTaskService : IHabitTaskService
             {
                 Code = 500,
                 Message = "An unexpected error occurred while fetching the habit task.",
+                Details = ex.Message
+            });
+        }
+    }
+
+    public async Task<EvidenceStorageResponseDto> CreateEvidenceAsync(int taskId, CreateEvidenceRequestDto request)
+    {
+        try
+        {
+            if (!await _habitTaskRepository.ExistsAsync(taskId))
+            {
+                throw new NotFoundError(new ErrorResponse
+                {
+                    Code = 404,
+                    Message = $"Task with ID {taskId} not found.",
+                    Details = "The requested habit task does not exist in the database."
+                });
+            }
+
+            var evidence = new EvidenceStorage
+            {
+                HabitTaskId = taskId,
+                EvidencePathUrl = request.EvidencePathUrl,
+                HealthDataJson = request.HealthDataJson,
+                UploadedAt = request.UploadedAt!.Value,
+            };
+
+            var created = await _habitTaskRepository.AddEvidenceAsync(evidence);
+
+            return new EvidenceStorageResponseDto
+            {
+                Id = created.Id,
+                HabitTaskId = created.HabitTaskId,
+                EvidencePathUrl = created.EvidencePathUrl,
+                HealthDataJson = created.HealthDataJson,
+                UploadedAt = created.UploadedAt
+            };
+        }
+        catch (NotFoundError)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new ServerError(500, new ErrorResponse
+            {
+                Code = 500,
+                Message = "An unexpected error occurred while creating the evidence record.",
                 Details = ex.Message
             });
         }

--- a/Services/IHabitTaskService.cs
+++ b/Services/IHabitTaskService.cs
@@ -1,3 +1,4 @@
+using LevelUpLifeBackend.DTOs.Requests;
 using LevelUpLifeBackend.DTOs.Responses;
 
 namespace LevelUpLifeBackend.Services;
@@ -5,6 +6,7 @@ namespace LevelUpLifeBackend.Services;
 public interface IHabitTaskService
 {
     Task<HabitTaskResponseDto> GetByIdAsync(int taskId);
+    Task<EvidenceStorageResponseDto> CreateEvidenceAsync(int taskId, CreateEvidenceRequestDto request);
     Task<IEnumerable<EvidenceStorageResponseDto>> GetEvidencesByTaskIdAsync(int taskId);
     Task<EvidenceStorageResponseDto> GetEvidenceByIdAsync(int taskId, int id);
 }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

Adds a `POST /habit-tasks/{taskId}/evidences` endpoint to upload evidence records for a completed task. Supports photo/video URLs, health data JSON, or both. The client is responsible for setting `FEC_UPLOADED` to the current UTC datetime.

---

## 🎯 Purpose

Allow clients to register evidence of task completion, enabling the habit tracking flow to record proof of activity (photos, videos, or health metrics).

---

## 🔄 Type of Change

- [x] ✨ New feature

---

## 🧪 How Has This Been Tested?

- [x] Manual testing

Tested against dev database (taskId: 9):

- `POST /habit-tasks/9/evidences` with `DSC_EVIDENCE_PATH_URL` only → 201
- `POST /habit-tasks/9/evidences` with `DSC_HEALTH_DATA_JSON` only → 201
- `POST /habit-tasks/9/evidences` with both fields → 201
- Body with neither field → 400 with field-level validation error
- Body with `FEC_UPLOADED` omitted → 400 (`FEC_UPLOADED is required.`)
- Body with `FEC_UPLOADED: null` or invalid format → 400 (JSON deserialization error)
- `POST /habit-tasks/9999/evidences` → 404 (task not found)
- Persistence verified via `GET /habit-tasks/9/evidences` after creation

---

## 📸 Screenshots (if applicable)

N/A

---

## 🚀 Deployment Notes (if needed)

None. The `LULT_HABIT_TASK_EVIDENCE_STORAGE` table already exists in the database. No migrations required.

---

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [x] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #39
