### PR TITLE
feat(habit-tasks): add DELETE endpoint to permanently remove evidence

### DIFF
--- a/Controllers/HabitTaskController.cs
+++ b/Controllers/HabitTaskController.cs
@@ -270,6 +270,33 @@ public class HabitTaskController : ControllerBase
         }
     }
 
+    [HttpDelete("{taskId:int}/evidences/{id:int}")]
+    public async Task<IActionResult> DeleteEvidence(int taskId, int id)
+    {
+        try
+        {
+            await _habitTaskService.DeleteEvidenceAsync(taskId, id);
+            return Ok(new { message = "Evidence deleted successfully." });
+        }
+        catch (NotFoundError ex)
+        {
+            return NotFound(ex.Payload);
+        }
+        catch (ServerError ex)
+        {
+            return StatusCode(ex.HttpStatusCode, ex.Payload);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new ErrorResponse
+            {
+                Code = 500,
+                Message = "An unexpected error occurred.",
+                Details = ex.Message
+            });
+        }
+    }
+
     private int? ResolveUserId()
     {
         var headerValue = Request.Headers["X-User-Id"].FirstOrDefault();

--- a/Repositories/HabitTaskRepository.cs
+++ b/Repositories/HabitTaskRepository.cs
@@ -75,6 +75,12 @@ public class HabitTaskRepository : IHabitTaskRepository
             .FirstOrDefaultAsync(e => e.HabitTaskId == taskId && e.Id == id);
     }
 
+    public async Task DeleteEvidenceAsync(EvidenceStorage evidence)
+    {
+        _context.EvidenceStorages.Remove(evidence);
+        await _context.SaveChangesAsync();
+    }
+
     public async Task<bool> ExistsAsync(int taskId)
     {
         return await _context.HabitTasks.AnyAsync(ht => ht.Id == taskId);

--- a/Repositories/IHabitTaskRepository.cs
+++ b/Repositories/IHabitTaskRepository.cs
@@ -10,5 +10,6 @@ public interface IHabitTaskRepository
     Task<HabitTask?> GetByIdWithCriteriaAsync(int id);
     Task<IEnumerable<EvidenceStorage>> GetEvidencesByTaskIdAsync(int taskId);
     Task<EvidenceStorage?> GetEvidenceByIdAsync(int taskId, int id);
+    Task DeleteEvidenceAsync(EvidenceStorage evidence);
     Task<bool> ExistsAsync(int taskId);
 }

--- a/Services/HabitTaskService.cs
+++ b/Services/HabitTaskService.cs
@@ -136,4 +136,47 @@ public class HabitTaskService : IHabitTaskService
             });
         }
     }
+
+    public async Task DeleteEvidenceAsync(int taskId, int id)
+    {
+        try
+        {
+            if (!await _habitTaskRepository.ExistsAsync(taskId))
+            {
+                throw new NotFoundError(new ErrorResponse
+                {
+                    Code = 404,
+                    Message = $"Task with ID {taskId} not found.",
+                    Details = "The requested habit task does not exist in the database."
+                });
+            }
+
+            var evidence = await _habitTaskRepository.GetEvidenceByIdAsync(taskId, id);
+
+            if (evidence == null)
+            {
+                throw new NotFoundError(new ErrorResponse
+                {
+                    Code = 404,
+                    Message = $"Evidence with ID {id} not found for Task {taskId}.",
+                    Details = "The requested evidence record does not exist or does not belong to the specified task."
+                });
+            }
+
+            await _habitTaskRepository.DeleteEvidenceAsync(evidence);
+        }
+        catch (NotFoundError)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new ServerError(500, new ErrorResponse
+            {
+                Code = 500,
+                Message = "An unexpected error occurred while deleting the evidence record.",
+                Details = ex.Message
+            });
+        }
+    }
 }

--- a/Services/IHabitTaskService.cs
+++ b/Services/IHabitTaskService.cs
@@ -7,4 +7,5 @@ public interface IHabitTaskService
     Task<HabitTaskResponseDto> GetByIdAsync(int taskId);
     Task<IEnumerable<EvidenceStorageResponseDto>> GetEvidencesByTaskIdAsync(int taskId);
     Task<EvidenceStorageResponseDto> GetEvidenceByIdAsync(int taskId, int id);
+    Task DeleteEvidenceAsync(int taskId, int id);
 }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

This PR adds a new endpoint to permanently delete an evidence record from a habit task:

`DELETE /api/habit-tasks/{taskId}/evidences/{id}`

This is a **hard delete** — the record is removed from the database and cannot be undone.

**Response (200):**
```json
{
  "message": "Evidence deleted successfully."
}
```

**Error responses:**
- `404` — Task with the given `taskId` does not exist
- `404` — Evidence with the given `id` does not exist or does not belong to the specified task
- `500` — Unexpected server error

**Changes:**
- `Controllers/HabitTaskController.cs` — new `DeleteEvidence` action (`DELETE {taskId:int}/evidences/{id:int}`), returns 200 with a confirmation message; maps `NotFoundError` → 404 and `ServerError` → 500, following the same pattern as the existing evidence endpoints.
- `Services/IHabitTaskService.cs` / `HabitTaskService.cs` — new `DeleteEvidenceAsync(taskId, id)`: validates the task exists, validates the evidence exists and belongs to the task, then performs the deletion. Unexpected exceptions are wrapped in `ServerError`.
- `Repositories/IHabitTaskRepository.cs` / `HabitTaskRepository.cs` — new `DeleteEvidenceAsync(evidence)` performing a hard delete via `Remove()` + `SaveChangesAsync()`.

---

## 🎯 Purpose

Users need to be able to remove evidence records that were uploaded by mistake or are no longer valid. Until now there was no way to delete an evidence record once created — the API only supported listing and fetching evidences. This endpoint completes the evidence management flow for habit tasks.

---

## 🔄 Type of Change

Please check the relevant option:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

Explain the testing process:

Verified manually against the running API (`http://localhost:5223`) connected to the real PostgreSQL database:

| Scenario | Result |
|---|---|
| `DELETE /api/habit-tasks/9/evidences/6` (valid taskId and evidence id) | ✅ 200 `{"message":"Evidence deleted successfully."}` |
| `GET /api/habit-tasks/9/evidences` after delete | ✅ Evidence 6 no longer present in the list |
| Repeat the same DELETE (already deleted) | ✅ 404 `Evidence with ID 6 not found for Task 9.` |
| `DELETE /api/habit-tasks/9999/evidences/3` (task not found) | ✅ 404 `Task with ID 9999 not found.` |
| `DELETE /api/habit-tasks/9/evidences/9999` (evidence not found) | ✅ 404 `Evidence with ID 9999 not found for Task 9.` |

Build: 0 warnings, 0 errors.

---

## 📸 Screenshots (if applicable)

N/A — API-only change. Response samples are included in the testing table above.

---

## 🚀 Deployment Notes (if needed)

No special steps required. No database migrations, no configuration changes, no new dependencies.

---

## ✅ Checklist

Before requesting a review, please confirm:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [x] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues


