### PR TITLE
Get list disciplines

### DIFF
--- a/Controllers/HabitDisciplineApiController.cs
+++ b/Controllers/HabitDisciplineApiController.cs
@@ -18,6 +18,33 @@ public class HabitDisciplineApiController : ControllerBase
         _habitDisciplineService = habitDisciplineService;
     }
 
+    [Authorize]
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        try
+        {
+            var disciplines = await _habitDisciplineService.GetAllDisciplinesAsync();
+            return Ok(disciplines);
+        }
+        catch (ServerError ex)
+        {
+            return StatusCode(ex.HttpStatusCode, ex.Payload);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(
+                500,
+                new ErrorResponse
+                {
+                    Code = 500,
+                    Message = "An unexpected error occurred.",
+                    Details = ex.Message,
+                }
+            );
+        }
+    }
+
     [HttpGet("{id:int}")]
     public async Task<IActionResult> GetById(int id)
     {

--- a/LevelUpLife-Backend.Tests/HabitDisciplineServiceTests.cs
+++ b/LevelUpLife-Backend.Tests/HabitDisciplineServiceTests.cs
@@ -24,6 +24,54 @@ public class HabitDisciplineServiceTests
     }
 
     [Fact]
+    public async Task GetAllDisciplinesAsync_WhenDisciplinesExist_ReturnsMappedDtos()
+    {
+        var disciplines = new List<HabitDiscipline>
+        {
+            new()
+            {
+                Id = 1,
+                Name = "Strength",
+                Description = "Physical training",
+                IsActive = true,
+                Category = new HabitCategory { Id = 3 },
+            },
+            new()
+            {
+                Id = 2,
+                Name = "Meditation",
+                Description = "Mindfulness practice",
+                IsActive = false,
+                Category = new HabitCategory { Id = 5 },
+            },
+        };
+
+        _repositoryMock.Setup(r => r.GetAllAsync()).ReturnsAsync(disciplines);
+
+        var result = (await _service.GetAllDisciplinesAsync()).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1, result[0].IdHabitDiscipline);
+        Assert.Equal(3, result[0].IdHabitCategory);
+        Assert.Equal("Strength", result[0].DscHabitDisciplineName);
+        Assert.Equal("Physical training", result[0].DscHabitDisciplineDescription);
+        Assert.True(result[0].StatusHabitDisciplineIsActive);
+        Assert.Equal(2, result[1].IdHabitDiscipline);
+        Assert.Equal(5, result[1].IdHabitCategory);
+        Assert.False(result[1].StatusHabitDisciplineIsActive);
+    }
+
+    [Fact]
+    public async Task GetAllDisciplinesAsync_WhenRepositoryThrowsException_ThrowsServerError()
+    {
+        _repositoryMock.Setup(r => r.GetAllAsync()).ThrowsAsync(new Exception("Database error"));
+
+        var exception = await Assert.ThrowsAsync<ServerError>(() => _service.GetAllDisciplinesAsync());
+
+        Assert.Equal(500, exception.HttpStatusCode);
+    }
+
+    [Fact]
     public async Task GetDisciplineByIdAsync_WhenDisciplineExists_ReturnsDto()
     {
         var discipline = new HabitDiscipline

--- a/Repositories/HabitDisciplineRepository.cs
+++ b/Repositories/HabitDisciplineRepository.cs
@@ -13,6 +13,14 @@ public class HabitDisciplineRepository : IHabitDisciplineRepository
         _context = context;
     }
 
+    public async Task<IEnumerable<HabitDiscipline>> GetAllAsync()
+    {
+        return await _context.Disciplines
+            .AsNoTracking()
+            .Include(d => d.Category)
+            .ToListAsync();
+    }
+
     public async Task<HabitDiscipline?> GetByIdAsync(int id)
     {
         return await _context.Disciplines

--- a/Repositories/IHabitDisciplineRepository.cs
+++ b/Repositories/IHabitDisciplineRepository.cs
@@ -4,6 +4,8 @@ namespace LevelUpLifeBackend.Repositories;
 
 public interface IHabitDisciplineRepository
 {
+    Task<IEnumerable<HabitDiscipline>> GetAllAsync();
+
     Task<HabitDiscipline?> GetByIdAsync(int id);
 
     Task<HabitDiscipline> AddAsync(HabitDiscipline discipline);

--- a/Services/HabitDisciplineService.cs
+++ b/Services/HabitDisciplineService.cs
@@ -19,6 +19,27 @@ public class HabitDisciplineService : IHabitDisciplineService
         _habitCategoryRepository = habitCategoryRepository;
     }
 
+    public async Task<IEnumerable<HabitDisciplineDetailResponseDto>> GetAllDisciplinesAsync()
+    {
+        try
+        {
+            var disciplines = await _habitDisciplineRepository.GetAllAsync();
+            return disciplines.Select(d => MapToDto(d));
+        }
+        catch (Exception ex)
+        {
+            throw new ServerError(
+                500,
+                new ErrorResponse
+                {
+                    Code = 500,
+                    Message = "An unexpected error occurred while fetching habit disciplines.",
+                    Details = ex.Message,
+                }
+            );
+        }
+    }
+
     public async Task<HabitDisciplineDetailResponseDto> GetDisciplineByIdAsync(int id)
     {
         try
@@ -37,14 +58,7 @@ public class HabitDisciplineService : IHabitDisciplineService
                 );
             }
 
-            return new HabitDisciplineDetailResponseDto
-            {
-                IdHabitDiscipline = discipline.Id,
-                IdHabitCategory = discipline.Category.Id,
-                DscHabitDisciplineName = discipline.Name,
-                DscHabitDisciplineDescription = discipline.Description,
-                StatusHabitDisciplineIsActive = discipline.IsActive,
-            };
+            return MapToDto(discipline);
         }
         catch (NotFoundError)
         {
@@ -93,14 +107,7 @@ public class HabitDisciplineService : IHabitDisciplineService
 
             var created = await _habitDisciplineRepository.AddAsync(discipline);
 
-            return new HabitDisciplineDetailResponseDto
-            {
-                IdHabitDiscipline = created.Id,
-                IdHabitCategory = request.IdHabitCategory,
-                DscHabitDisciplineName = created.Name,
-                DscHabitDisciplineDescription = created.Description,
-                StatusHabitDisciplineIsActive = created.IsActive,
-            };
+            return MapToDto(created, request.IdHabitCategory);
         }
         catch (AppError)
         {
@@ -118,5 +125,19 @@ public class HabitDisciplineService : IHabitDisciplineService
                 }
             );
         }
+    }
+
+    private static HabitDisciplineDetailResponseDto MapToDto(
+        HabitDiscipline discipline,
+        int? categoryId = null)
+    {
+        return new HabitDisciplineDetailResponseDto
+        {
+            IdHabitDiscipline = discipline.Id,
+            IdHabitCategory = categoryId ?? discipline.Category.Id,
+            DscHabitDisciplineName = discipline.Name,
+            DscHabitDisciplineDescription = discipline.Description,
+            StatusHabitDisciplineIsActive = discipline.IsActive,
+        };
     }
 }

--- a/Services/IHabitDisciplineService.cs
+++ b/Services/IHabitDisciplineService.cs
@@ -5,6 +5,8 @@ namespace LevelUpLifeBackend.Services;
 
 public interface IHabitDisciplineService
 {
+    Task<IEnumerable<HabitDisciplineDetailResponseDto>> GetAllDisciplinesAsync();
+
     Task<HabitDisciplineDetailResponseDto> GetDisciplineByIdAsync(int id);
 
     Task<HabitDisciplineDetailResponseDto> CreateDisciplineAsync(CreateHabitDisciplineRequestDto request);


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

This PR implements the **List Disciplines** endpoint (`GET /api/habit/disciplines`), which returns all habit disciplines mapped to the `HabitDisciplineDetailResponseDto` shape, including the parent `idHabitCategory` for each entry.

Changes span the repository, service, controller, and unit test layers:

- Added `GetAllAsync()` to `IHabitDisciplineRepository` / `HabitDisciplineRepository` (with `Category` eagerly loaded).
- Added `GetAllDisciplinesAsync()` to `IHabitDisciplineService` / `HabitDisciplineService`, mapping entities via a shared `MapToDto()` helper.
- Added an authenticated `GET` action on `HabitDisciplineApiController` at `api/habit/disciplines`.
- Added unit tests covering successful list mapping and `ServerError` on repository failure.

---

## 🎯 Purpose

Clients need a way to fetch all available habit disciplines (with their parent category ID) to populate UI selectors and support habit creation flows.

This change provides a single, JWT-protected read endpoint that returns a consistent response contract and follows existing discipline patterns (`ServerError` on failure, `[Authorize]` for authentication).

---

## 🔄 Type of Change

Please check the relevant option:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

Describe the tests you ran and how you verified your changes.

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests

Explain the testing process:

**Unit tests** (`HabitDisciplineServiceTests`):
- `GetAllDisciplinesAsync_WhenDisciplinesExist_ReturnsMappedDtos` — verifies each item is mapped with `idHabitDiscipline`, `idHabitCategory`, name, description, and active status.
- `GetAllDisciplinesAsync_WhenRepositoryThrowsException_ThrowsServerError` — verifies a `ServerError` (500) is thrown when the repository fails.

**Manual testing** (local, `http://localhost:5223`):
- Confirmed existing seed data in PostgreSQL (`LULM_HABIT_DISCIPLINE` contains at least one record: `Ejercicio`).
- `POST /api/auth/login` → obtained JWT.
- `GET /api/habit/disciplines` with `Authorization: Bearer <token>` → **200** with expected JSON array.
- `GET /api/habit/disciplines` without token or with invalid token → **401 Unauthorized**.
- **500** can be reproduced with a valid JWT while PostgreSQL is stopped or the connection string points to an unreachable database.

**Example curl (200):**
```bash
TOKEN=$(curl -s -X POST http://localhost:5223/api/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"userNameOrEmail":"curltester","password":"Test1234"}' \
  | jq -r '.data.token')

curl -s http://localhost:5223/api/habit/disciplines \
  -H "Authorization: Bearer $TOKEN" | jq
```

**Example response (200):**
```json
[
  {
    "idHabitDiscipline": 1,
    "idHabitCategory": 1,
    "dscHabitDisciplineName": "Ejercicio",
    "dscHabitDisciplineDescription": "Actividad física diaria",
    "statusHabitDisciplineIsActive": true
  }
]
```

**Example curl (401 — no token):**
```bash
curl -i http://localhost:5223/api/habit/disciplines
```

**Example curl (401 — invalid token):**
```bash
curl -i http://localhost:5223/api/habit/disciplines \
  -H "Authorization: Bearer token.invalido"
```

**Example curl (401 — malformed Authorization header):**
```bash
curl -i http://localhost:5223/api/habit/disciplines \
  -H "Authorization: Bearer"
```

**Example curl (500 — database unavailable):**
```bash
# 1) Obtener token
TOKEN=$(curl -s -X POST http://localhost:5223/api/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"userNameOrEmail":"curltester","password":"Test1234"}' \
  | jq -r '.data.token')

# 2) Detener Postgres (ejemplo en Linux)
sudo systemctl stop postgresql

# 3) Llamar el endpoint
curl -i http://localhost:5223/api/habit/disciplines \
  -H "Authorization: Bearer $TOKEN"

# 4) Volver a levantar Postgres
sudo systemctl start postgresql
```

**Example response (500):**
```json
{
  "code": 500,
  "message": "An unexpected error occurred while fetching habit disciplines.",
  "details": "..."
}
```

---

## 📸 Screenshots (if applicable)

### Obtain disciplines 
<img width="942" height="415" alt="image" src="https://github.com/user-attachments/assets/edb0f41a-727e-4561-b4a5-e570edd8bdde" />

### 401 cases
<img width="976" height="922" alt="image" src="https://github.com/user-attachments/assets/11fd10bd-85fd-4cf3-ad57-580c263e717b" />

### 500 case
<img width="891" height="723" alt="image" src="https://github.com/user-attachments/assets/ae18b5eb-5961-4973-a62b-25a7da885af1" />


---

## 🚀 Deployment Notes (if needed)

No special deployment steps required. Ensure:

- Database migrations are applied (existing `LULM_HABIT_DISCIPLINE` / `LULM_HABIT_CATEGORY` tables).
- JWT configuration (`Jwt:Key`, `Jwt:Issuer`, `Jwt:Audience`) is set in the target environment.

---

## ✅ Checklist

Before requesting a review, please confirm:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #19
Linked to #19
