### PR TITLE
22 update disciplines

### DIFF
--- a/Controllers/HabitDisciplineApiController.cs
+++ b/Controllers/HabitDisciplineApiController.cs
@@ -49,6 +49,48 @@ public class HabitDisciplineApiController : ControllerBase
     }
 
     [Authorize]
+    [HttpPut("{id:int}")]
+    public async Task<IActionResult> Update(int id, [FromBody] UpdateHabitDisciplineRequestDto request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var updated = await _habitDisciplineService.UpdateDisciplineAsync(id, request);
+            return Ok(updated);
+        }
+        catch (NotFoundError ex)
+        {
+            return NotFound(ex.Payload);
+        }
+        catch (AppError ex) when (ex.HttpStatusCode == StatusCodes.Status400BadRequest)
+        {
+            var modelState = new ModelStateDictionary();
+            modelState.AddModelError("idHabitCategory", ex.Payload.Details ?? ex.Payload.Message);
+            return ValidationProblem(modelState);
+        }
+        catch (ServerError ex)
+        {
+            return StatusCode(ex.HttpStatusCode, ex.Payload);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(
+                500,
+                new ErrorResponse
+                {
+                    Code = 500,
+                    Message = "An unexpected error occurred.",
+                    Details = ex.Message,
+                }
+            );
+        }
+    }
+
+    [Authorize]
     [HttpPost]
     public async Task<IActionResult> Create([FromBody] CreateHabitDisciplineRequestDto request)
     {

--- a/DTOs/Requests/UpdateHabitDisciplineRequestDto.cs
+++ b/DTOs/Requests/UpdateHabitDisciplineRequestDto.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace LevelUpLifeBackend.DTOs.Requests;
+
+public class UpdateHabitDisciplineRequestDto
+{
+    [Required(ErrorMessage = "idHabitCategory is required.")]
+    [Range(1, int.MaxValue, ErrorMessage = "idHabitCategory must be greater than 0.")]
+    [JsonPropertyName("idHabitCategory")]
+    [Display(Name = "idHabitCategory")]
+    public int IdHabitCategory { get; set; }
+
+    [Required(ErrorMessage = "dscHabitDisciplineName is required.")]
+    [StringLength(50, MinimumLength = 1, ErrorMessage = "dscHabitDisciplineName must be between 1 and 50 characters.")]
+    [JsonPropertyName("dscHabitDisciplineName")]
+    [Display(Name = "dscHabitDisciplineName")]
+    public string DscHabitDisciplineName { get; set; } = string.Empty;
+
+    [JsonPropertyName("dscHabitDisciplineDescription")]
+    [Display(Name = "dscHabitDisciplineDescription")]
+    public string? DscHabitDisciplineDescription { get; set; }
+
+    [JsonPropertyName("statusHabitDisciplineIsActive")]
+    [Display(Name = "statusHabitDisciplineIsActive")]
+    public bool StatusHabitDisciplineIsActive { get; set; } = true;
+}

--- a/LevelUpLife-Backend.Tests/HabitDisciplineServiceTests.cs
+++ b/LevelUpLife-Backend.Tests/HabitDisciplineServiceTests.cs
@@ -112,4 +112,102 @@ public class HabitDisciplineServiceTests
 
         Assert.Equal(400, exception.HttpStatusCode);
     }
+
+    [Fact]
+    public async Task UpdateDisciplineAsync_WhenDisciplineExists_ReturnsUpdatedDto()
+    {
+        var existing = new HabitDiscipline
+        {
+            Id = 7,
+            Name = "Strength",
+            Description = "Old description",
+            IsActive = true,
+            Category = new HabitCategory { Id = 3 },
+        };
+
+        var request = new UpdateHabitDisciplineRequestDto
+        {
+            IdHabitCategory = 2,
+            DscHabitDisciplineName = "Cardio",
+            DscHabitDisciplineDescription = "Updated description",
+            StatusHabitDisciplineIsActive = false,
+        };
+
+        _repositoryMock.Setup(r => r.GetByIdForUpdateAsync(7)).ReturnsAsync(existing);
+        _categoryRepositoryMock.Setup(r => r.GetByIdAsync(2)).ReturnsAsync(new HabitCategory { Id = 2 });
+        _repositoryMock
+            .Setup(r => r.UpdateAsync(It.IsAny<HabitDiscipline>(), It.IsAny<int>()))
+            .ReturnsAsync((HabitDiscipline discipline, int categoryId) =>
+            {
+                discipline.Category = new HabitCategory { Id = categoryId };
+                return discipline;
+            });
+
+        var result = await _service.UpdateDisciplineAsync(7, request);
+
+        Assert.Equal(7, result.IdHabitDiscipline);
+        Assert.Equal(2, result.IdHabitCategory);
+        Assert.Equal("Cardio", result.DscHabitDisciplineName);
+        Assert.Equal("Updated description", result.DscHabitDisciplineDescription);
+        Assert.False(result.StatusHabitDisciplineIsActive);
+    }
+
+    [Fact]
+    public async Task UpdateDisciplineAsync_WhenDisciplineDoesNotExist_ThrowsNotFoundError()
+    {
+        var request = new UpdateHabitDisciplineRequestDto
+        {
+            IdHabitCategory = 1,
+            DscHabitDisciplineName = "Cardio",
+        };
+
+        _repositoryMock.Setup(r => r.GetByIdForUpdateAsync(999)).ReturnsAsync((HabitDiscipline?)null);
+
+        var exception = await Assert.ThrowsAsync<NotFoundError>(
+            () => _service.UpdateDisciplineAsync(999, request));
+
+        Assert.Equal(404, exception.HttpStatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateDisciplineAsync_WhenCategoryDoesNotExist_ThrowsAppError400()
+    {
+        var existing = new HabitDiscipline
+        {
+            Id = 7,
+            Name = "Strength",
+            Category = new HabitCategory { Id = 3 },
+        };
+
+        var request = new UpdateHabitDisciplineRequestDto
+        {
+            IdHabitCategory = 999,
+            DscHabitDisciplineName = "Cardio",
+        };
+
+        _repositoryMock.Setup(r => r.GetByIdForUpdateAsync(7)).ReturnsAsync(existing);
+        _categoryRepositoryMock.Setup(r => r.GetByIdAsync(999)).ReturnsAsync((HabitCategory?)null);
+
+        var exception = await Assert.ThrowsAsync<AppError>(
+            () => _service.UpdateDisciplineAsync(7, request));
+
+        Assert.Equal(400, exception.HttpStatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateDisciplineAsync_WhenRepositoryThrowsException_ThrowsServerError()
+    {
+        var request = new UpdateHabitDisciplineRequestDto
+        {
+            IdHabitCategory = 1,
+            DscHabitDisciplineName = "Cardio",
+        };
+
+        _repositoryMock.Setup(r => r.GetByIdForUpdateAsync(1)).ThrowsAsync(new Exception("Database error"));
+
+        var exception = await Assert.ThrowsAsync<ServerError>(
+            () => _service.UpdateDisciplineAsync(1, request));
+
+        Assert.Equal(500, exception.HttpStatusCode);
+    }
 }

--- a/Repositories/HabitDisciplineRepository.cs
+++ b/Repositories/HabitDisciplineRepository.cs
@@ -21,10 +21,22 @@ public class HabitDisciplineRepository : IHabitDisciplineRepository
             .FirstOrDefaultAsync(d => d.Id == id);
     }
 
+    public async Task<HabitDiscipline?> GetByIdForUpdateAsync(int id)
+    {
+        return await _context.Disciplines.FirstOrDefaultAsync(d => d.Id == id);
+    }
+
     public async Task<HabitDiscipline> AddAsync(HabitDiscipline discipline)
     {
         _context.Entry(discipline.Category).State = EntityState.Unchanged;
         await _context.Disciplines.AddAsync(discipline);
+        await _context.SaveChangesAsync();
+        return discipline;
+    }
+
+    public async Task<HabitDiscipline> UpdateAsync(HabitDiscipline discipline, int categoryId)
+    {
+        _context.Entry(discipline).Property("CategoryId").CurrentValue = categoryId;
         await _context.SaveChangesAsync();
         return discipline;
     }

--- a/Repositories/IHabitDisciplineRepository.cs
+++ b/Repositories/IHabitDisciplineRepository.cs
@@ -6,5 +6,9 @@ public interface IHabitDisciplineRepository
 {
     Task<HabitDiscipline?> GetByIdAsync(int id);
 
+    Task<HabitDiscipline?> GetByIdForUpdateAsync(int id);
+
     Task<HabitDiscipline> AddAsync(HabitDiscipline discipline);
+
+    Task<HabitDiscipline> UpdateAsync(HabitDiscipline discipline, int categoryId);
 }

--- a/Services/HabitDisciplineService.cs
+++ b/Services/HabitDisciplineService.cs
@@ -119,4 +119,76 @@ public class HabitDisciplineService : IHabitDisciplineService
             );
         }
     }
+
+    public async Task<HabitDisciplineDetailResponseDto> UpdateDisciplineAsync(
+        int id,
+        UpdateHabitDisciplineRequestDto request)
+    {
+        try
+        {
+            var discipline = await _habitDisciplineRepository.GetByIdForUpdateAsync(id);
+            if (discipline is null)
+            {
+                throw new NotFoundError(
+                    new ErrorResponse
+                    {
+                        Code = 404,
+                        Message = $"Discipline with ID {id} not found.",
+                        Details = "The requested habit discipline does not exist in the database.",
+                    }
+                );
+            }
+
+            var category = await _habitCategoryRepository.GetByIdAsync(request.IdHabitCategory);
+            if (category is null)
+            {
+                throw new AppError(
+                    StatusCodes.Status400BadRequest,
+                    new ErrorResponse
+                    {
+                        Code = 400,
+                        Message = "Validation failed.",
+                        Details = "The specified habit category does not exist.",
+                    }
+                );
+            }
+
+            discipline.Name = request.DscHabitDisciplineName.Trim();
+            discipline.Description = request.DscHabitDisciplineDescription?.Trim() ?? string.Empty;
+            discipline.IsActive = request.StatusHabitDisciplineIsActive;
+
+            var updated = await _habitDisciplineRepository.UpdateAsync(
+                discipline,
+                request.IdHabitCategory);
+
+            return new HabitDisciplineDetailResponseDto
+            {
+                IdHabitDiscipline = updated.Id,
+                IdHabitCategory = request.IdHabitCategory,
+                DscHabitDisciplineName = updated.Name,
+                DscHabitDisciplineDescription = updated.Description,
+                StatusHabitDisciplineIsActive = updated.IsActive,
+            };
+        }
+        catch (NotFoundError)
+        {
+            throw;
+        }
+        catch (AppError)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new ServerError(
+                500,
+                new ErrorResponse
+                {
+                    Code = 500,
+                    Message = "An unexpected error occurred while updating the habit discipline.",
+                    Details = ex.Message,
+                }
+            );
+        }
+    }
 }

--- a/Services/IHabitDisciplineService.cs
+++ b/Services/IHabitDisciplineService.cs
@@ -8,4 +8,8 @@ public interface IHabitDisciplineService
     Task<HabitDisciplineDetailResponseDto> GetDisciplineByIdAsync(int id);
 
     Task<HabitDisciplineDetailResponseDto> CreateDisciplineAsync(CreateHabitDisciplineRequestDto request);
+
+    Task<HabitDisciplineDetailResponseDto> UpdateDisciplineAsync(
+        int id,
+        UpdateHabitDisciplineRequestDto request);
 }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

This PR implements the **Update Discipline** endpoint (`PUT /api/habit/disciplines/{id}`), which sends updated discipline fields to the API and returns the updated `HabitDisciplineDetailResponseDto` on success.

Changes span the repository, service, controller, and unit test layers:

- Added `UpdateHabitDisciplineRequestDto` with field-level validation attributes.
- Added `GetByIdForUpdateAsync()` and `UpdateAsync()` to `IHabitDisciplineRepository` / `HabitDisciplineRepository` (uses shadow property `CategoryId` to avoid EF Core tracking conflicts).
- Added `UpdateDisciplineAsync()` to `IHabitDisciplineService` / `HabitDisciplineService`.
- Added an authenticated `PUT` action on `HabitDisciplineApiController`.
- Added unit tests covering success, 404, 400, and 500 scenarios.

---

## 🎯 Purpose

Clients need a way to update an existing habit discipline (category, name, description, and active status) and receive the updated model in the response.

This change provides a JWT-protected update endpoint that returns field-level validation errors on **400**, `NotFoundError` on **404**, and `ServerError` on **500**, following existing discipline endpoint patterns.

---

## 🔄 Type of Change

Please check the relevant option:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

Describe the tests you ran and how you verified your changes.

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests

Explain the testing process:

**Unit tests** (`HabitDisciplineServiceTests`):
- `UpdateDisciplineAsync_WhenDisciplineExists_ReturnsUpdatedDto` — verifies **200** mapping with all updated fields including `idHabitCategory`.
- `UpdateDisciplineAsync_WhenDisciplineDoesNotExist_ThrowsNotFoundError` — verifies **404** `NotFoundError`.
- `UpdateDisciplineAsync_WhenCategoryDoesNotExist_ThrowsAppError400` — verifies **400** for invalid category.
- `UpdateDisciplineAsync_WhenRepositoryThrowsException_ThrowsServerError` — verifies **500** `ServerError`.

**Manual testing** (local, `http://localhost:5223`):
- `POST /api/auth/login` → obtained JWT.
- `PUT /api/habit/disciplines/{id}` with valid body → **200** with updated discipline.
- `PUT` without token / with invalid token → **401 Unauthorized**.
- `PUT` with non-existent discipline ID → **404**.
- `PUT` with invalid category or empty name → **400** with field-level errors.
- **500** reproducible with valid JWT while PostgreSQL is stopped.

**Example curl (200):**
```bash
TOKEN=$(curl -s -X POST http://localhost:5223/api/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"userNameOrEmail":"curltester","password":"Test1234"}' \
  | jq -r '.data.token')

curl -s -X PUT http://localhost:5223/api/habit/disciplines/1 \
  -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{
    "idHabitCategory": 1,
    "dscHabitDisciplineName": "Ejercicio Actualizado",
    "dscHabitDisciplineDescription": "Nueva descripción",
    "statusHabitDisciplineIsActive": true
  }' | jq
```

**Example response (200):**
```json
{
  "idHabitDiscipline": 1,
  "idHabitCategory": 1,
  "dscHabitDisciplineName": "Ejercicio Actualizado",
  "dscHabitDisciplineDescription": "Nueva descripción",
  "statusHabitDisciplineIsActive": true
}
```

**Example curl (401 — no token):**
```bash
curl -i -X PUT http://localhost:5223/api/habit/disciplines/1 \
  -H 'Content-Type: application/json' \
  -d '{
    "idHabitCategory": 1,
    "dscHabitDisciplineName": "Test",
    "dscHabitDisciplineDescription": "Test",
    "statusHabitDisciplineIsActive": true
  }'
```

**Example curl (401 — invalid token):**
```bash
curl -i -X PUT http://localhost:5223/api/habit/disciplines/1 \
  -H "Authorization: Bearer token.invalido" \
  -H 'Content-Type: application/json' \
  -d '{
    "idHabitCategory": 1,
    "dscHabitDisciplineName": "Test",
    "dscHabitDisciplineDescription": "Test",
    "statusHabitDisciplineIsActive": true
  }'
```

**Example curl (401 — malformed Authorization header):**
```bash
curl -i -X PUT http://localhost:5223/api/habit/disciplines/1 \
  -H "Authorization: Bearer" \
  -H 'Content-Type: application/json' \
  -d '{
    "idHabitCategory": 1,
    "dscHabitDisciplineName": "Test",
    "dscHabitDisciplineDescription": "Test",
    "statusHabitDisciplineIsActive": true
  }'
```

**Example curl (404 — discipline not found):**
```bash
TOKEN=$(curl -s -X POST http://localhost:5223/api/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"userNameOrEmail":"curltester","password":"Test1234"}' \
  | jq -r '.data.token')

curl -i -X PUT http://localhost:5223/api/habit/disciplines/9999 \
  -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{
    "idHabitCategory": 1,
    "dscHabitDisciplineName": "Test",
    "dscHabitDisciplineDescription": "Test",
    "statusHabitDisciplineIsActive": true
  }'
```

**Example response (404):**
```json
{
  "code": 404,
  "message": "Discipline with ID 9999 not found.",
  "details": "The requested habit discipline does not exist in the database."
}
```

**Example curl (400 — invalid category):**
```bash
TOKEN=$(curl -s -X POST http://localhost:5223/api/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"userNameOrEmail":"curltester","password":"Test1234"}' \
  | jq -r '.data.token')

curl -i -X PUT http://localhost:5223/api/habit/disciplines/1 \
  -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{
    "idHabitCategory": 9999,
    "dscHabitDisciplineName": "Test",
    "dscHabitDisciplineDescription": "Test",
    "statusHabitDisciplineIsActive": true
  }'
```

**Example curl (400 — field validation, empty name):**
```bash
TOKEN=$(curl -s -X POST http://localhost:5223/api/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"userNameOrEmail":"curltester","password":"Test1234"}' \
  | jq -r '.data.token')

curl -i -X PUT http://localhost:5223/api/habit/disciplines/1 \
  -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{
    "idHabitCategory": 1,
    "dscHabitDisciplineName": "",
    "dscHabitDisciplineDescription": "Test",
    "statusHabitDisciplineIsActive": true
  }'
```

**Example curl (500 — database unavailable):**
```bash
# 1) Obtener token
TOKEN=$(curl -s -X POST http://localhost:5223/api/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"userNameOrEmail":"curltester","password":"Test1234"}' \
  | jq -r '.data.token')

# 2) Detener Postgres (ejemplo en Linux)
sudo systemctl stop postgresql

# 3) Llamar el endpoint
curl -i -X PUT http://localhost:5223/api/habit/disciplines/1 \
  -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{
    "idHabitCategory": 1,
    "dscHabitDisciplineName": "Ejercicio Actualizado",
    "dscHabitDisciplineDescription": "Nueva descripción",
    "statusHabitDisciplineIsActive": true
  }'

# 4) Volver a levantar Postgres
sudo systemctl start postgresql
```

**Example response (500):**
```json
{
  "code": 500,
  "message": "An unexpected error occurred while updating the habit discipline.",
  "details": "..."
}
```

---

## 📸 Screenshots (if applicable)

###Updated
<img width="875" height="555" alt="image" src="https://github.com/user-attachments/assets/34b0e16a-89f5-4330-883f-a016d7b3567e" />

###404 cases
<img width="1273" height="500" alt="image" src="https://github.com/user-attachments/assets/8b8b9da6-da95-490a-a41a-1e121c5a4d28" />

### 400 cases
<img width="1244" height="456" alt="image" src="https://github.com/user-attachments/assets/392fef61-4627-40e4-9522-a0f184546cdc" />

<img width="1222" height="486" alt="image" src="https://github.com/user-attachments/assets/46b37017-a92a-4380-9c67-b128b41435f0" />


---

## 🚀 Deployment Notes (if needed)

No special deployment steps required. Ensure:

- Database migrations are applied (existing `LULM_HABIT_DISCIPLINE` / `LULM_HABIT_CATEGORY` tables).
- JWT configuration (`Jwt:Key`, `Jwt:Issuer`, `Jwt:Audience`) is set in the target environment.

---

## ✅ Checklist

Before requesting a review, please confirm:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #22
Linked to #22
