### PR TITLE
Soft Delete from desactivate Habits

### DIFF
--- a/Controllers/HabitDisciplineApiController.cs
+++ b/Controllers/HabitDisciplineApiController.cs
@@ -76,6 +76,44 @@ public class HabitDisciplineApiController : ControllerBase
     }
 
     [Authorize]
+    [HttpPatch("{id:int}")]
+    public async Task<IActionResult> UpdateStatus(
+        int id,
+        [FromBody] UpdateHabitDisciplineStatusRequestDto request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var (success, message) = await _habitDisciplineService.UpdateDisciplineStatusAsync(id, request);
+            return Ok(new { success, message });
+        }
+        catch (NotFoundError ex)
+        {
+            return NotFound(ex.Payload);
+        }
+        catch (ServerError ex)
+        {
+            return StatusCode(ex.HttpStatusCode, ex.Payload);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(
+                500,
+                new ErrorResponse
+                {
+                    Code = 500,
+                    Message = "An unexpected error occurred.",
+                    Details = ex.Message,
+                }
+            );
+        }
+    }
+
+    [Authorize]
     [HttpPost]
     public async Task<IActionResult> Create([FromBody] CreateHabitDisciplineRequestDto request)
     {

--- a/DTOs/Requests/UpdateHabitDisciplineStatusRequestDto.cs
+++ b/DTOs/Requests/UpdateHabitDisciplineStatusRequestDto.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace LevelUpLifeBackend.DTOs.Requests;
+
+public class UpdateHabitDisciplineStatusRequestDto
+{
+    [Required(ErrorMessage = "statusHabitDisciplineIsActive is required.")]
+    [JsonPropertyName("statusHabitDisciplineIsActive")]
+    [Display(Name = "statusHabitDisciplineIsActive")]
+    public bool StatusHabitDisciplineIsActive { get; set; }
+}

--- a/LevelUpLife-Backend.Tests/HabitDisciplineServiceTests.cs
+++ b/LevelUpLife-Backend.Tests/HabitDisciplineServiceTests.cs
@@ -160,4 +160,67 @@ public class HabitDisciplineServiceTests
 
         Assert.Equal(400, exception.HttpStatusCode);
     }
+
+    [Fact]
+    public async Task UpdateDisciplineStatusAsync_WhenDisciplineExists_DeactivatesAndReturnsSuccess()
+    {
+        var discipline = new HabitDiscipline
+        {
+            Id = 3,
+            Name = "Strength",
+            Description = "Physical training",
+            IsActive = true,
+            Category = new HabitCategory { Id = 1 },
+        };
+
+        _repositoryMock.Setup(r => r.GetTrackedByIdAsync(3)).ReturnsAsync(discipline);
+        _repositoryMock.Setup(r => r.UpdateAsync(discipline)).Returns(Task.CompletedTask);
+
+        var request = new UpdateHabitDisciplineStatusRequestDto
+        {
+            StatusHabitDisciplineIsActive = false,
+        };
+
+        var (success, message) = await _service.UpdateDisciplineStatusAsync(3, request);
+
+        Assert.True(success);
+        Assert.Equal("Discipline deactivated successfully.", message);
+        Assert.False(discipline.IsActive);
+        _repositoryMock.Verify(r => r.UpdateAsync(discipline), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateDisciplineStatusAsync_WhenDisciplineDoesNotExist_ThrowsNotFoundError()
+    {
+        _repositoryMock.Setup(r => r.GetTrackedByIdAsync(999)).ReturnsAsync((HabitDiscipline?)null);
+
+        var request = new UpdateHabitDisciplineStatusRequestDto
+        {
+            StatusHabitDisciplineIsActive = false,
+        };
+
+        var exception = await Assert.ThrowsAsync<NotFoundError>(
+            () => _service.UpdateDisciplineStatusAsync(999, request));
+
+        Assert.Equal(404, exception.HttpStatusCode);
+        Assert.Equal(404, exception.Payload.Code);
+    }
+
+    [Fact]
+    public async Task UpdateDisciplineStatusAsync_WhenRepositoryThrowsException_ThrowsServerError()
+    {
+        _repositoryMock
+            .Setup(r => r.GetTrackedByIdAsync(1))
+            .ThrowsAsync(new Exception("Database error"));
+
+        var request = new UpdateHabitDisciplineStatusRequestDto
+        {
+            StatusHabitDisciplineIsActive = false,
+        };
+
+        var exception = await Assert.ThrowsAsync<ServerError>(
+            () => _service.UpdateDisciplineStatusAsync(1, request));
+
+        Assert.Equal(500, exception.HttpStatusCode);
+    }
 }

--- a/Repositories/HabitDisciplineRepository.cs
+++ b/Repositories/HabitDisciplineRepository.cs
@@ -36,4 +36,17 @@ public class HabitDisciplineRepository : IHabitDisciplineRepository
         await _context.SaveChangesAsync();
         return discipline;
     }
+
+    public async Task<HabitDiscipline?> GetTrackedByIdAsync(int id)
+    {
+        return await _context.Disciplines
+            .Include(d => d.Category)
+            .FirstOrDefaultAsync(d => d.Id == id);
+    }
+
+    public async Task UpdateAsync(HabitDiscipline discipline)
+    {
+        _context.Disciplines.Update(discipline);
+        await _context.SaveChangesAsync();
+    }
 }

--- a/Repositories/IHabitDisciplineRepository.cs
+++ b/Repositories/IHabitDisciplineRepository.cs
@@ -9,4 +9,8 @@ public interface IHabitDisciplineRepository
     Task<HabitDiscipline?> GetByIdAsync(int id);
 
     Task<HabitDiscipline> AddAsync(HabitDiscipline discipline);
+
+    Task<HabitDiscipline?> GetTrackedByIdAsync(int id);
+
+    Task UpdateAsync(HabitDiscipline discipline);
 }

--- a/Services/HabitDisciplineService.cs
+++ b/Services/HabitDisciplineService.cs
@@ -127,6 +127,53 @@ public class HabitDisciplineService : IHabitDisciplineService
         }
     }
 
+    public async Task<(bool Success, string Message)> UpdateDisciplineStatusAsync(
+        int id,
+        UpdateHabitDisciplineStatusRequestDto request)
+    {
+        try
+        {
+            var discipline = await _habitDisciplineRepository.GetTrackedByIdAsync(id);
+
+            if (discipline is null)
+            {
+                throw new NotFoundError(
+                    new ErrorResponse
+                    {
+                        Code = 404,
+                        Message = $"Discipline with ID {id} not found.",
+                        Details = "The requested habit discipline does not exist in the database.",
+                    }
+                );
+            }
+
+            discipline.IsActive = request.StatusHabitDisciplineIsActive;
+            await _habitDisciplineRepository.UpdateAsync(discipline);
+
+            var message = request.StatusHabitDisciplineIsActive
+                ? "Discipline activated successfully."
+                : "Discipline deactivated successfully.";
+
+            return (true, message);
+        }
+        catch (NotFoundError)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new ServerError(
+                500,
+                new ErrorResponse
+                {
+                    Code = 500,
+                    Message = "An unexpected error occurred while updating the habit discipline status.",
+                    Details = ex.Message,
+                }
+            );
+        }
+    }
+
     private static HabitDisciplineDetailResponseDto MapToDto(
         HabitDiscipline discipline,
         int? categoryId = null)

--- a/Services/IHabitDisciplineService.cs
+++ b/Services/IHabitDisciplineService.cs
@@ -10,4 +10,8 @@ public interface IHabitDisciplineService
     Task<HabitDisciplineDetailResponseDto> GetDisciplineByIdAsync(int id);
 
     Task<HabitDisciplineDetailResponseDto> CreateDisciplineAsync(CreateHabitDisciplineRequestDto request);
+
+    Task<(bool Success, string Message)> UpdateDisciplineStatusAsync(
+        int id,
+        UpdateHabitDisciplineStatusRequestDto request);
 }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

This PR implements the **Deactivate Discipline** endpoint for Issue #23. It adds a JWT-protected `PATCH /api/habit/disciplines/{id}` route that performs a soft delete by setting `statusHabitDisciplineIsActive` to `false` in the database.

Changes include:
- `UpdateHabitDisciplineStatusRequestDto` for the request body
- `UpdateDisciplineStatusAsync` in `HabitDisciplineService`
- `GetTrackedByIdAsync` and `UpdateAsync` in `HabitDisciplineRepository`
- `UpdateStatus` action in `HabitDisciplineApiController` with `[Authorize]`
- 3 new unit tests covering success, not found, and server error scenarios

**Request:**
```json
{
  "statusHabitDisciplineIsActive": false
}
```

**Response (200):**
```json
{
  "success": true,
  "message": "Discipline deactivated successfully."
}
```

---

## 🎯 Purpose

Habit disciplines need to be deactivated without being permanently deleted from the database. This endpoint allows clients to toggle the active flag while preserving existing data and relationships.

This change is necessary to complete the discipline lifecycle (create → read → deactivate) and satisfy the acceptance criteria defined in Issue #23.

---

## 🔄 Type of Change

Please check the relevant option:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

Describe the tests you ran and how you verified your changes.

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests

Explain the testing process:

**Unit tests** (`HabitDisciplineServiceTests`):
- `UpdateDisciplineStatusAsync_WhenDisciplineExists_DeactivatesAndReturnsSuccess`
- `UpdateDisciplineStatusAsync_WhenDisciplineDoesNotExist_ThrowsNotFoundError`
- `UpdateDisciplineStatusAsync_WhenRepositoryThrowsException_ThrowsServerError`

All 10 tests in `HabitDisciplineServiceTests` pass.

**Manual testing** via `curl`:

```bash
# 1. Login — obtain JWT
TOKEN=$(curl -s -X POST http://localhost:5223/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"userNameOrEmail":"your@email.com","password":"your_password"}' \
  | jq -r '.data.token')

# Verify token is not empty
echo "$TOKEN"
```

```bash
# 2. Deactivate discipline — 200 OK
curl -s -i -X PATCH http://localhost:5223/api/habit/disciplines/1 \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -d '{"statusHabitDisciplineIsActive": false}'
```

```bash
# 3. Discipline not found — 404 NotFoundError
curl -s -i -X PATCH http://localhost:5223/api/habit/disciplines/99999 \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -d '{"statusHabitDisciplineIsActive": false}'
```

```bash
# 4. Missing JWT — 401 Unauthorized (handled by global JWT middleware)
curl -s -i -X PATCH http://localhost:5223/api/habit/disciplines/1 \
  -H "Content-Type: application/json" \
  -d '{"statusHabitDisciplineIsActive": false}'
```

```bash
# 5. Invalid request body with valid JWT — 400 Bad Request
curl -s -i -X PATCH http://localhost:5223/api/habit/disciplines/1 \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN"
```

| Scenario | Expected status |
|----------|-----------------|
| Valid ID + valid JWT + `{ "statusHabitDisciplineIsActive": false }` | **200** |
| Non-existent discipline ID | **404** |
| Missing or invalid JWT | **401** |
| Empty or malformed body (with valid JWT) | **400** |

---

## 📸 Screenshots (if applicable)

### Desactivate with token
<img width="924" height="265" alt="image" src="https://github.com/user-attachments/assets/7efc9a19-f870-43d2-932a-a49dba0eceb1" />

### 401
<img width="932" height="220" alt="image" src="https://github.com/user-attachments/assets/7c809721-382b-44ea-bd1f-37d199da04a1" />

### 400
<img width="1600" height="342" alt="image" src="https://github.com/user-attachments/assets/58f75c54-8444-4e53-b19a-6e2b7bec4ed5" />


---

## 🚀 Deployment Notes (if needed)

No special deployment steps required. Standard migration and restart flow applies. No new database migrations were added — the endpoint uses the existing `STATUS_HABIT_DISCIPLINE_IS_ACTIVE` column.

---

## ✅ Checklist

Before requesting a review, please confirm:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #23
Linked to #23
