### PR TITLE
feat: progressive XP leveling (#89) + player bio/avatar profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ appsettings.Development.json
 appsettings.Development.example.json
 appsettings.json
 cookies.txt
+uploads/

--- a/Controllers/PlayerController.cs
+++ b/Controllers/PlayerController.cs
@@ -54,6 +54,7 @@ public class PlayerController : ControllerBase
     }
 
     [HttpPut("update")]
+    [HttpPatch("update")]
     public async Task<IActionResult> UpdateProfile([FromBody] UpdatePlayerProfileRequestDto request)
     {
         var userIdResult = ResolveAuthenticatedUserId();
@@ -106,6 +107,85 @@ public class PlayerController : ControllerBase
                 code = 400,
                 message = "Bad Request",
                 details = result.Details ?? "Datos inválidos."
+            }),
+            _ => StatusCode(StatusCodes.Status500InternalServerError, new
+            {
+                code = 500,
+                message = "Internal Server Error",
+                details = "Unexpected error occurred"
+            })
+        };
+    }
+
+    [HttpPost("profile/avatar")]
+    [RequestSizeLimit(5 * 1024 * 1024)]
+    [RequestFormLimits(MultipartBodyLengthLimit = 5 * 1024 * 1024)]
+    public async Task<IActionResult> UploadAvatar(IFormFile? file)
+    {
+        var userIdResult = ResolveAuthenticatedUserId();
+        if (userIdResult is null)
+        {
+            return Unauthorized(new
+            {
+                code = 401,
+                message = "Unauthorized",
+                details = "Token inválido o sin identificador de usuario."
+            });
+        }
+
+        if (!Request.Headers.TryGetValue("If-Match", out var ifMatchHeader) || string.IsNullOrWhiteSpace(ifMatchHeader))
+        {
+            return BadRequest(new
+            {
+                code = 400,
+                message = "Bad Request",
+                details = "El header If-Match es requerido."
+            });
+        }
+
+        if (file is null || file.Length == 0)
+        {
+            return BadRequest(new
+            {
+                code = 400,
+                message = "Bad Request",
+                details = "Debe enviar un archivo de imagen en el campo 'file'."
+            });
+        }
+
+        await using var stream = file.OpenReadStream();
+        var result = await _playerService.UploadAvatarAsync(
+            userIdResult.Value,
+            ifMatchHeader.ToString(),
+            stream,
+            file.ContentType,
+            file.Length);
+
+        return result.Status switch
+        {
+            UploadPlayerAvatarStatus.Success => BuildSuccessResponse(new UpdatePlayerProfileServiceResult
+            {
+                Status = UpdatePlayerProfileStatus.Success,
+                Response = result.Response,
+                ETag = result.ETag
+            }),
+            UploadPlayerAvatarStatus.NotFound => NotFound(new
+            {
+                code = 404,
+                message = "Not Found",
+                details = "No se encontró el jugador solicitado."
+            }),
+            UploadPlayerAvatarStatus.ETagMismatch => StatusCode(StatusCodes.Status412PreconditionFailed, new
+            {
+                code = 412,
+                message = "Precondition Failed",
+                details = "El recurso fue modificado por otra operación. Obtenga el ETag actualizado."
+            }),
+            UploadPlayerAvatarStatus.InvalidData => BadRequest(new
+            {
+                code = 400,
+                message = "Bad Request",
+                details = result.Details ?? "Archivo de avatar inválido."
             }),
             _ => StatusCode(StatusCodes.Status500InternalServerError, new
             {

--- a/DTOs/Requests/UpdatePlayerProfileRequestDto.cs
+++ b/DTOs/Requests/UpdatePlayerProfileRequestDto.cs
@@ -29,6 +29,9 @@ public class PlayerDataUpdateRequestDto
 
     public int? PreferredClassId { get; set; }
 
+    [StringLength(500)]
+    public string? Bio { get; set; }
+
     // El modelo actual no persiste timezone, pero el contrato la acepta.
     public string? Timezone { get; set; }
 }

--- a/DTOs/Responses/CompleteHabitTaskResponseDto.cs
+++ b/DTOs/Responses/CompleteHabitTaskResponseDto.cs
@@ -1,8 +1,39 @@
+using System.Text.Json.Serialization;
+
 namespace LevelUpLifeBackend.DTOs.Responses;
 
 public class CompleteHabitTaskResponseDto
 {
+    [JsonPropertyName("xpEarned")]
     public int XpEarned { get; set; }
+
+    [JsonPropertyName("previousLevel")]
+    public int PreviousLevel { get; set; }
+
+    [JsonPropertyName("newLevel")]
     public int NewLevel { get; set; }
+
+    [JsonPropertyName("totalExperiencePoints")]
+    public int TotalExperiencePoints { get; set; }
+
+    [JsonPropertyName("experiencePointsInCurrentLevel")]
+    public int ExperiencePointsInCurrentLevel { get; set; }
+
+    [JsonPropertyName("experiencePointsRequiredForNextLevel")]
+    public int ExperiencePointsRequiredForNextLevel { get; set; }
+
+    [JsonPropertyName("levelProgressPercent")]
+    public double LevelProgressPercent { get; set; }
+
+    [JsonPropertyName("leveledUp")]
+    public bool LeveledUp { get; set; }
+
+    [JsonPropertyName("streakUpdated")]
     public bool StreakUpdated { get; set; }
+
+    [JsonPropertyName("daysStreak")]
+    public int DaysStreak { get; set; }
+
+    [JsonPropertyName("levelingConfig")]
+    public LevelingConfigDto LevelingConfig { get; set; } = new();
 }

--- a/DTOs/Responses/GetPlayerProfileResponseDto.cs
+++ b/DTOs/Responses/GetPlayerProfileResponseDto.cs
@@ -13,6 +13,21 @@ public class GetPlayerProfileResponseDto
     [JsonPropertyName("PlayerUserLevel")]
     public int PlayerUserLevel { get; set; }
 
+    [JsonPropertyName("totalExperiencePoints")]
+    public int TotalExperiencePoints { get; set; }
+
+    [JsonPropertyName("experiencePointsInCurrentLevel")]
+    public int ExperiencePointsInCurrentLevel { get; set; }
+
+    [JsonPropertyName("experiencePointsRequiredForNextLevel")]
+    public int ExperiencePointsRequiredForNextLevel { get; set; }
+
+    [JsonPropertyName("levelProgressPercent")]
+    public double LevelProgressPercent { get; set; }
+
+    [JsonPropertyName("levelingConfig")]
+    public LevelingConfigDto LevelingConfig { get; set; } = new();
+
     [JsonPropertyName("statusIsActive")]
     public bool StatusIsActive { get; set; }
 

--- a/DTOs/Responses/GetPlayerProfileResponseDto.cs
+++ b/DTOs/Responses/GetPlayerProfileResponseDto.cs
@@ -34,6 +34,15 @@ public class GetPlayerProfileResponseDto
     [JsonPropertyName("PlayerUserLastLogin")]
     public DateTime? PlayerUserLastLogin { get; set; }
 
+    [JsonPropertyName("PlayerUserCreationDate")]
+    public DateTime PlayerUserCreationDate { get; set; }
+
+    [JsonPropertyName("bio")]
+    public string? Bio { get; set; }
+
+    [JsonPropertyName("avatarUrl")]
+    public string? AvatarUrl { get; set; }
+
     [JsonPropertyName("PersonData")]
     public GetPlayerProfilePersonDataDto PersonData { get; set; } = new();
 }

--- a/DTOs/Responses/LevelProgressDto.cs
+++ b/DTOs/Responses/LevelProgressDto.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace LevelUpLifeBackend.DTOs.Responses;
+
+public class LevelProgressDto
+{
+    [JsonPropertyName("currentLevel")]
+    public int CurrentLevel { get; set; }
+
+    [JsonPropertyName("totalExperiencePoints")]
+    public int TotalExperiencePoints { get; set; }
+
+    [JsonPropertyName("experiencePointsInCurrentLevel")]
+    public int ExperiencePointsInCurrentLevel { get; set; }
+
+    [JsonPropertyName("experiencePointsRequiredForNextLevel")]
+    public int ExperiencePointsRequiredForNextLevel { get; set; }
+
+    [JsonPropertyName("levelProgressPercent")]
+    public double LevelProgressPercent { get; set; }
+}

--- a/DTOs/Responses/LevelingConfigDto.cs
+++ b/DTOs/Responses/LevelingConfigDto.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace LevelUpLifeBackend.DTOs.Responses;
+
+public class LevelingConfigDto
+{
+    [JsonPropertyName("strategy")]
+    public string Strategy { get; set; } = "escalating_percent";
+
+    [JsonPropertyName("baseXpPerLevel")]
+    public int BaseXpPerLevel { get; set; }
+
+    [JsonPropertyName("escalationPercent")]
+    public int EscalationPercent { get; set; }
+}

--- a/DTOs/Responses/LoginResponseDto.cs
+++ b/DTOs/Responses/LoginResponseDto.cs
@@ -1,10 +1,17 @@
+using System.Text.Json.Serialization;
+
 namespace LevelUpLifeBackend.DTOs.Responses;
 
-// Lo que el backend devuelve tras un login exitoso.
 public class LoginResponseDto
 {
     public string Token { get; set; } = string.Empty;
     public string UserName { get; set; } = string.Empty;
     public int Level { get; set; }
     public string ClassName { get; set; } = string.Empty;
+
+    [JsonPropertyName("levelProgress")]
+    public LevelProgressDto LevelProgress { get; set; } = new();
+
+    [JsonPropertyName("levelingConfig")]
+    public LevelingConfigDto LevelingConfig { get; set; } = new();
 }

--- a/DTOs/Responses/UpdatePlayerProfileResponseDto.cs
+++ b/DTOs/Responses/UpdatePlayerProfileResponseDto.cs
@@ -16,6 +16,9 @@ public class PlayerProfileDto
     public DateTime? LastLogin { get; set; }
     public int ClassId { get; set; }
     public string ClassName { get; set; } = string.Empty;
+    public string? Bio { get; set; }
+    public string? AvatarUrl { get; set; }
+    public DateTime CreationDate { get; set; }
     public PersonProfileDto Person { get; set; } = new();
 }
 

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -101,6 +101,8 @@ public class AppDbContext : DbContext
             entity.Property(e => e.LastLogin).HasColumnName("FEC_PLAYER_USER_LAST_LOGIN");
             entity.Property(e => e.CreationDate).HasColumnName("FEC_PLAYER_USER_CREATION_DATE");
             entity.Property(e => e.IsActive).HasColumnName("STATUS_PLAYER_USER_IS_ACTIVE");
+            entity.Property(e => e.Bio).HasColumnName("DSC_PLAYER_USER_BIO").HasMaxLength(500);
+            entity.Property(e => e.AvatarUrl).HasColumnName("DSC_PLAYER_USER_AVATAR_URL").HasMaxLength(500);
         });
 
         // ==========================================================

--- a/Infrastructure/AvatarContentTypeValidator.cs
+++ b/Infrastructure/AvatarContentTypeValidator.cs
@@ -1,0 +1,56 @@
+namespace LevelUpLifeBackend.Infrastructure;
+
+public static class AvatarContentTypeValidator
+{
+    private static readonly Dictionary<string, string[]> Signatures = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["image/jpeg"] = ["FF D8 FF"],
+        ["image/png"] = ["89 50 4E 47 0D 0A 1A 0A"],
+        ["image/webp"] = ["52 49 46 46"],
+    };
+
+    public static bool IsAllowedContentType(string? contentType, IEnumerable<string> allowedContentTypes)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+        {
+            return false;
+        }
+
+        return allowedContentTypes.Contains(contentType.Trim(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    public static string ResolveExtension(string contentType) =>
+        contentType.ToLowerInvariant() switch
+        {
+            "image/jpeg" => ".jpg",
+            "image/png" => ".png",
+            "image/webp" => ".webp",
+            _ => string.Empty,
+        };
+
+    public static bool HasValidSignature(Stream stream, string contentType)
+    {
+        if (!Signatures.TryGetValue(contentType, out var expectedSignatures))
+        {
+            return false;
+        }
+
+        var originalPosition = stream.CanSeek ? stream.Position : 0;
+        Span<byte> header = stackalloc byte[12];
+        var read = stream.Read(header);
+
+        if (stream.CanSeek)
+        {
+            stream.Position = originalPosition;
+        }
+
+        if (read <= 0)
+        {
+            return false;
+        }
+
+        var headerHex = Convert.ToHexString(header[..read]);
+        return expectedSignatures.Any(signature =>
+            headerHex.StartsWith(signature.Replace(" ", string.Empty), StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/Infrastructure/Configuration/LevelingOptions.cs
+++ b/Infrastructure/Configuration/LevelingOptions.cs
@@ -1,0 +1,12 @@
+namespace LevelUpLifeBackend.Infrastructure.Configuration;
+
+public class LevelingOptions
+{
+    public const string SectionName = "Leveling";
+
+    public LevelingStrategy Strategy { get; set; } = LevelingStrategy.EscalatingPercent;
+
+    public int BaseXpPerLevel { get; set; } = 100;
+
+    public int EscalationPercent { get; set; } = 20;
+}

--- a/Infrastructure/Configuration/LevelingStrategy.cs
+++ b/Infrastructure/Configuration/LevelingStrategy.cs
@@ -1,0 +1,6 @@
+namespace LevelUpLifeBackend.Infrastructure.Configuration;
+
+public enum LevelingStrategy
+{
+    EscalatingPercent,
+}

--- a/Infrastructure/Configuration/PlayerProfileOptions.cs
+++ b/Infrastructure/Configuration/PlayerProfileOptions.cs
@@ -1,0 +1,21 @@
+namespace LevelUpLifeBackend.Infrastructure.Configuration;
+
+public class PlayerProfileOptions
+{
+    public const string SectionName = "PlayerProfile";
+
+    public int MaxBioLength { get; set; } = 500;
+
+    public long MaxAvatarBytes { get; set; } = 5 * 1024 * 1024;
+
+    public string[] AllowedAvatarContentTypes { get; set; } =
+    [
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+    ];
+
+    public string AvatarStoragePath { get; set; } = "uploads/avatars";
+
+    public string AvatarPublicBasePath { get; set; } = "/uploads/avatars";
+}

--- a/LevelUpLife-Backend.Tests/HabitServiceUpdateTaskTests.cs
+++ b/LevelUpLife-Backend.Tests/HabitServiceUpdateTaskTests.cs
@@ -1,11 +1,13 @@
 using LevelUpLifeBackend.Data;
 using LevelUpLifeBackend.DTOs.Requests;
+using LevelUpLifeBackend.Infrastructure.Configuration;
 using LevelUpLifeBackend.Infrastructure.Errors;
 using LevelUpLifeBackend.Models;
 using LevelUpLifeBackend.Repositories;
 using LevelUpLifeBackend.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -21,6 +23,16 @@ public class HabitServiceUpdateTaskTests
             .Options;
         return new AppDbContext(options);
     }
+
+    private static ILevelProgressService CreateLevelProgressService() =>
+        new LevelProgressService(
+            Options.Create(
+                new LevelingOptions
+                {
+                    Strategy = LevelingStrategy.EscalatingPercent,
+                    BaseXpPerLevel = 100,
+                    EscalationPercent = 20,
+                }));
 
     private static HabitService CreateService(
         AppDbContext context,
@@ -39,6 +51,7 @@ public class HabitServiceUpdateTaskTests
             criteriaRepo.Object,
             timerRepo.Object,
             streakLogRepo.Object,
+            CreateLevelProgressService(),
             context
         );
     }
@@ -276,6 +289,12 @@ public class HabitServiceUpdateTaskTests
         Assert.Equal(50, task.EarnedXpSnapshot);
         Assert.Equal(50, result.XpEarned);
         Assert.Equal(1, result.NewLevel);
+        Assert.Equal(1, result.PreviousLevel);
+        Assert.False(result.LeveledUp);
+        Assert.Equal(50, result.TotalExperiencePoints);
+        Assert.Equal(50, result.ExperiencePointsInCurrentLevel);
+        Assert.Equal(100, result.ExperiencePointsRequiredForNextLevel);
+        Assert.Equal(0.5, result.LevelProgressPercent);
         Assert.True(result.StreakUpdated);
         Assert.Equal(50, task.Habit!.User.ExperiencePoints);
         taskRepo.Verify(
@@ -415,7 +434,13 @@ public class HabitServiceUpdateTaskTests
         );
 
         Assert.Equal(2, result.NewLevel);
+        Assert.Equal(1, result.PreviousLevel);
+        Assert.True(result.LeveledUp);
         Assert.Equal(100, result.XpEarned);
+        Assert.Equal(150, result.TotalExperiencePoints);
+        Assert.Equal(50, result.ExperiencePointsInCurrentLevel);
+        Assert.Equal(100, result.ExperiencePointsRequiredForNextLevel);
+        Assert.Equal(0.5, result.LevelProgressPercent);
     }
 
     [Fact]

--- a/LevelUpLife-Backend.Tests/LevelProgressServiceTests.cs
+++ b/LevelUpLife-Backend.Tests/LevelProgressServiceTests.cs
@@ -1,0 +1,131 @@
+using LevelUpLifeBackend.Infrastructure.Configuration;
+using LevelUpLifeBackend.Services;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace LevelUpLife_Backend.Tests;
+
+public class LevelProgressServiceTests
+{
+    private static LevelProgressService CreateService(
+        int baseXp = 100,
+        int escalationPercent = 20)
+    {
+        return new LevelProgressService(
+            Options.Create(
+                new LevelingOptions
+                {
+                    Strategy = LevelingStrategy.EscalatingPercent,
+                    BaseXpPerLevel = baseXp,
+                    EscalationPercent = escalationPercent,
+                }));
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(99, 1)]
+    [InlineData(100, 2)]
+    [InlineData(199, 2)]
+    [InlineData(200, 3)]
+    public void CalculateLevel_MapsTotalXpToProgressiveLevel(int totalXp, int expectedLevel)
+    {
+        var service = CreateService();
+
+        Assert.Equal(expectedLevel, service.CalculateLevel(totalXp));
+    }
+
+    [Fact]
+    public void GetXpRequiredForLevel_UsesSameBaseForLevelsOneAndTwo()
+    {
+        var service = CreateService();
+
+        Assert.Equal(100, service.GetXpRequiredForLevel(1));
+        Assert.Equal(100, service.GetXpRequiredForLevel(2));
+    }
+
+    [Fact]
+    public void GetXpRequiredForLevel_EscalatesTwentyPercentFromLevelThree()
+    {
+        var service = CreateService();
+
+        Assert.Equal(120, service.GetXpRequiredForLevel(3));
+        Assert.Equal(144, service.GetXpRequiredForLevel(4));
+    }
+
+    [Fact]
+    public void GetTotalXpForLevel_MatchesProgressiveThresholdTable()
+    {
+        var service = CreateService();
+
+        Assert.Equal(0, service.GetTotalXpForLevel(1));
+        Assert.Equal(100, service.GetTotalXpForLevel(2));
+        Assert.Equal(200, service.GetTotalXpForLevel(3));
+        Assert.Equal(320, service.GetTotalXpForLevel(4));
+    }
+
+    [Fact]
+    public void GetLevelProgress_WhenMidTier_ReturnsPartialProgress()
+    {
+        var service = CreateService();
+        var progress = service.GetLevelProgress(145);
+
+        Assert.Equal(2, progress.CurrentLevel);
+        Assert.Equal(45, progress.ExperiencePointsInCurrentLevel);
+        Assert.Equal(100, progress.ExperiencePointsRequiredForNextLevel);
+        Assert.Equal(0.45, progress.LevelProgressPercent);
+    }
+
+    [Fact]
+    public void GetLevelProgress_WhenExactlyAtLevelUpBoundary_ResetsProgressInNewTier()
+    {
+        var service = CreateService();
+        var progress = service.GetLevelProgress(200);
+
+        Assert.Equal(3, progress.CurrentLevel);
+        Assert.Equal(0, progress.ExperiencePointsInCurrentLevel);
+        Assert.Equal(120, progress.ExperiencePointsRequiredForNextLevel);
+        Assert.Equal(0.0, progress.LevelProgressPercent);
+    }
+
+    [Fact]
+    public void ToCompleteResponse_WhenNoLevelUp_ReturnsAccurateProgressFields()
+    {
+        var service = CreateService();
+        var response = service.ToCompleteResponse(
+            xpEarned: 10,
+            previousLevel: 1,
+            totalExperiencePoints: 10,
+            streakUpdated: true,
+            daysStreak: 2);
+
+        Assert.Equal(10, response.XpEarned);
+        Assert.Equal(1, response.PreviousLevel);
+        Assert.Equal(1, response.NewLevel);
+        Assert.False(response.LeveledUp);
+        Assert.Equal(10, response.ExperiencePointsInCurrentLevel);
+        Assert.Equal(100, response.ExperiencePointsRequiredForNextLevel);
+        Assert.Equal(0.1, response.LevelProgressPercent);
+        Assert.True(response.StreakUpdated);
+        Assert.Equal(2, response.DaysStreak);
+        Assert.Equal("escalating_percent", response.LevelingConfig.Strategy);
+    }
+
+    [Fact]
+    public void ToCompleteResponse_WhenLevelUp_ReturnsPreviousAndNewLevel()
+    {
+        var service = CreateService();
+        var response = service.ToCompleteResponse(
+            xpEarned: 100,
+            previousLevel: 1,
+            totalExperiencePoints: 150,
+            streakUpdated: true,
+            daysStreak: 1);
+
+        Assert.Equal(1, response.PreviousLevel);
+        Assert.Equal(2, response.NewLevel);
+        Assert.True(response.LeveledUp);
+        Assert.Equal(50, response.ExperiencePointsInCurrentLevel);
+        Assert.Equal(100, response.ExperiencePointsRequiredForNextLevel);
+        Assert.Equal(0.5, response.LevelProgressPercent);
+    }
+}

--- a/LevelUpLife-Backend.Tests/PlayerProfilePersistenceTests.cs
+++ b/LevelUpLife-Backend.Tests/PlayerProfilePersistenceTests.cs
@@ -1,0 +1,196 @@
+using LevelUpLifeBackend.DTOs.Requests;
+using LevelUpLifeBackend.Infrastructure.Configuration;
+using LevelUpLifeBackend.Models;
+using LevelUpLifeBackend.Repositories;
+using LevelUpLifeBackend.Services;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace LevelUpLifeBackend.Tests;
+
+public class PlayerProfilePersistenceTests
+{
+    private readonly Mock<IPlayerRepository> _playerRepositoryMock;
+    private readonly Mock<IAvatarStorageService> _avatarStorageMock;
+    private readonly PlayerService _playerService;
+
+    public PlayerProfilePersistenceTests()
+    {
+        _playerRepositoryMock = new Mock<IPlayerRepository>();
+        _avatarStorageMock = new Mock<IAvatarStorageService>();
+        _avatarStorageMock
+            .Setup(s => s.SaveAvatarAsync(It.IsAny<int>(), It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("/uploads/avatars/1/sample.png");
+        _avatarStorageMock
+            .Setup(s => s.DeleteAvatarIfExistsAsync(It.IsAny<string?>()))
+            .Returns(Task.CompletedTask);
+
+        _playerService = new PlayerService(
+            _playerRepositoryMock.Object,
+            new LevelProgressService(
+                Options.Create(
+                    new LevelingOptions
+                    {
+                        Strategy = LevelingStrategy.EscalatingPercent,
+                        BaseXpPerLevel = 100,
+                        EscalationPercent = 20,
+                    })),
+            _avatarStorageMock.Object,
+            Options.Create(new PlayerProfileOptions()));
+    }
+
+    [Fact]
+    public async Task GetProfileAsync_ReturnsBioAndAvatarUrl()
+    {
+        var player = CreatePlayer();
+        player.Bio = "Habit builder";
+        player.AvatarUrl = "/uploads/avatars/1/avatar.png";
+
+        _playerRepositoryMock
+            .Setup(repo => repo.GetActiveByIdWithRelationsAsync(1))
+            .ReturnsAsync(player);
+
+        var result = await _playerService.GetProfileAsync(1);
+
+        Assert.Equal("Habit builder", result.Response!.Bio);
+        Assert.Equal("/uploads/avatars/1/avatar.png", result.Response.AvatarUrl);
+    }
+
+    [Fact]
+    public async Task UpdateProfileAsync_WhenBioIsValid_PersistsBio()
+    {
+        var player = CreatePlayer();
+        _playerRepositoryMock
+            .Setup(repo => repo.GetActiveByIdWithRelationsAsync(1))
+            .ReturnsAsync(player);
+        _playerRepositoryMock
+            .Setup(repo => repo.SaveChangesAsync())
+            .Returns(Task.CompletedTask);
+
+        var etag = await GetCurrentETag(player);
+        var result = await _playerService.UpdateProfileAsync(
+            1,
+            etag,
+            new UpdatePlayerProfileRequestDto
+            {
+                PlayerData = new PlayerDataUpdateRequestDto
+                {
+                    Bio = "  New bio  ",
+                },
+            });
+
+        Assert.Equal(UpdatePlayerProfileStatus.Success, result.Status);
+        Assert.Equal("New bio", player.Bio);
+        Assert.Equal("New bio", result.Response!.Player.Bio);
+    }
+
+    [Fact]
+    public async Task UpdateProfileAsync_WhenBioIsTooLong_ReturnsInvalidData()
+    {
+        var player = CreatePlayer();
+        _playerRepositoryMock
+            .Setup(repo => repo.GetActiveByIdWithRelationsAsync(1))
+            .ReturnsAsync(player);
+
+        var etag = await GetCurrentETag(player);
+        var result = await _playerService.UpdateProfileAsync(
+            1,
+            etag,
+            new UpdatePlayerProfileRequestDto
+            {
+                PlayerData = new PlayerDataUpdateRequestDto
+                {
+                    Bio = new string('a', 501),
+                },
+            });
+
+        Assert.Equal(UpdatePlayerProfileStatus.InvalidData, result.Status);
+    }
+
+    [Fact]
+    public async Task UploadAvatarAsync_WhenImageIsValid_UpdatesAvatarUrl()
+    {
+        var player = CreatePlayer();
+        _playerRepositoryMock
+            .Setup(repo => repo.GetActiveByIdWithRelationsAsync(1))
+            .ReturnsAsync(player);
+        _playerRepositoryMock
+            .Setup(repo => repo.SaveChangesAsync())
+            .Returns(Task.CompletedTask);
+
+        var etag = await GetCurrentETag(player);
+        await using var pngStream = new MemoryStream(
+            Convert.FromHexString("89504E470D0A1A0A0000000000000000"));
+
+        var result = await _playerService.UploadAvatarAsync(
+            1,
+            etag,
+            pngStream,
+            "image/png",
+            pngStream.Length);
+
+        Assert.Equal(UploadPlayerAvatarStatus.Success, result.Status);
+        Assert.Equal("/uploads/avatars/1/sample.png", player.AvatarUrl);
+        Assert.Equal("/uploads/avatars/1/sample.png", result.Response!.Player.AvatarUrl);
+    }
+
+    [Fact]
+    public async Task UploadAvatarAsync_WhenMimeTypeIsInvalid_ReturnsInvalidData()
+    {
+        var player = CreatePlayer();
+        _playerRepositoryMock
+            .Setup(repo => repo.GetActiveByIdWithRelationsAsync(1))
+            .ReturnsAsync(player);
+
+        var etag = await GetCurrentETag(player);
+        await using var stream = new MemoryStream([0x00, 0x01, 0x02]);
+
+        var result = await _playerService.UploadAvatarAsync(
+            1,
+            etag,
+            stream,
+            "application/pdf",
+            stream.Length);
+
+        Assert.Equal(UploadPlayerAvatarStatus.InvalidData, result.Status);
+    }
+
+    private async Task<string> GetCurrentETag(PlayerUser player)
+    {
+        _playerRepositoryMock
+            .Setup(repo => repo.GetActiveByIdWithRelationsAsync(player.Id))
+            .ReturnsAsync(player);
+
+        var profile = await _playerService.GetProfileAsync(player.Id);
+        return profile.ETag!;
+    }
+
+    private static PlayerUser CreatePlayer()
+    {
+        return new PlayerUser
+        {
+            Id = 1,
+            UserName = "testuser",
+            Level = 1,
+            ExperiencePoints = 0,
+            CreationDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            IsActive = true,
+            Person = new Person
+            {
+                Id = 10,
+                Name = "Test",
+                LastName = "User",
+                Email = "test@leveluplife.com",
+                BirthDate = new DateOnly(1990, 1, 1),
+                IsActive = true,
+            },
+            Class = new UserPlayerClass
+            {
+                Id = 2,
+                Name = "Warrior",
+                IsActive = true,
+            },
+        };
+    }
+}

--- a/LevelUpLife-Backend.Tests/PlayerProgressMapperTests.cs
+++ b/LevelUpLife-Backend.Tests/PlayerProgressMapperTests.cs
@@ -19,14 +19,4 @@ public class PlayerProgressMapperTests
 
         Assert.Equal(expectedXp, PlayerProgressMapper.CalculateXpEarned(task));
     }
-
-    [Theory]
-    [InlineData(0, 1)]
-    [InlineData(99, 1)]
-    [InlineData(100, 2)]
-    [InlineData(150, 2)]
-    public void CalculateLevel_MapsExperiencePointsToLevel(int experiencePoints, int expectedLevel)
-    {
-        Assert.Equal(expectedLevel, PlayerProgressMapper.CalculateLevel(experiencePoints));
-    }
 }

--- a/LevelUpLife-Backend.Tests/PlayerServiceTests.cs
+++ b/LevelUpLife-Backend.Tests/PlayerServiceTests.cs
@@ -16,6 +16,7 @@ public class PlayerServiceTests
     public PlayerServiceTests()
     {
         _playerRepositoryMock = new Mock<IPlayerRepository>();
+        var avatarStorageMock = new Mock<IAvatarStorageService>();
         _playerService = new PlayerService(
             _playerRepositoryMock.Object,
             new LevelProgressService(
@@ -25,7 +26,9 @@ public class PlayerServiceTests
                         Strategy = LevelingStrategy.EscalatingPercent,
                         BaseXpPerLevel = 100,
                         EscalationPercent = 20,
-                    })));
+                    })),
+            avatarStorageMock.Object,
+            Options.Create(new PlayerProfileOptions()));
     }
 
     [Fact]
@@ -104,6 +107,7 @@ public class PlayerServiceTests
             UserName = "testuser",
             Level = 5,
             ExperiencePoints = 464,
+            CreationDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             IsActive = true,
             LastLogin = lastLogin,
             Person = new Person

--- a/LevelUpLife-Backend.Tests/PlayerServiceTests.cs
+++ b/LevelUpLife-Backend.Tests/PlayerServiceTests.cs
@@ -1,6 +1,8 @@
+using LevelUpLifeBackend.Infrastructure.Configuration;
 using LevelUpLifeBackend.Models;
 using LevelUpLifeBackend.Repositories;
 using LevelUpLifeBackend.Services;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -14,7 +16,16 @@ public class PlayerServiceTests
     public PlayerServiceTests()
     {
         _playerRepositoryMock = new Mock<IPlayerRepository>();
-        _playerService = new PlayerService(_playerRepositoryMock.Object);
+        _playerService = new PlayerService(
+            _playerRepositoryMock.Object,
+            new LevelProgressService(
+                Options.Create(
+                    new LevelingOptions
+                    {
+                        Strategy = LevelingStrategy.EscalatingPercent,
+                        BaseXpPerLevel = 100,
+                        EscalationPercent = 20,
+                    })));
     }
 
     [Fact]
@@ -92,6 +103,7 @@ public class PlayerServiceTests
             Id = 1,
             UserName = "testuser",
             Level = 5,
+            ExperiencePoints = 464,
             IsActive = true,
             LastLogin = lastLogin,
             Person = new Person

--- a/Mappers/PlayerProgressMapper.cs
+++ b/Mappers/PlayerProgressMapper.cs
@@ -1,4 +1,3 @@
-using LevelUpLifeBackend.DTOs.Responses;
 using LevelUpLifeBackend.Models;
 
 namespace LevelUpLifeBackend.Mappers;
@@ -18,25 +17,6 @@ public static class PlayerProgressMapper
             TaskDifficulty.MEDIUM => 25,
             TaskDifficulty.HARD => 50,
             _ => 10,
-        };
-    }
-
-    public static int CalculateLevel(int experiencePoints)
-    {
-        return Math.Max(1, 1 + experiencePoints / 100);
-    }
-
-    public static CompleteHabitTaskResponseDto ToCompleteResponse(
-        int xpEarned,
-        int newLevel,
-        bool streakUpdated
-    )
-    {
-        return new CompleteHabitTaskResponseDto
-        {
-            XpEarned = xpEarned,
-            NewLevel = newLevel,
-            StreakUpdated = streakUpdated,
         };
     }
 

--- a/Migrations/20260618224129_AddPlayerProfileBioAndAvatar.Designer.cs
+++ b/Migrations/20260618224129_AddPlayerProfileBioAndAvatar.Designer.cs
@@ -4,6 +4,7 @@ using LevelUpLifeBackend.Data;
 using LevelUpLifeBackend.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LevelUpLife_Backend.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260618224129_AddPlayerProfileBioAndAvatar")]
+    partial class AddPlayerProfileBioAndAvatar
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260618224129_AddPlayerProfileBioAndAvatar.cs
+++ b/Migrations/20260618224129_AddPlayerProfileBioAndAvatar.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LevelUpLife_Backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlayerProfileBioAndAvatar : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                ALTER TABLE "LULM_PLAYER_USER"
+                    ADD COLUMN IF NOT EXISTS "DSC_PLAYER_USER_BIO" VARCHAR(500);
+
+                ALTER TABLE "LULM_PLAYER_USER"
+                    ADD COLUMN IF NOT EXISTS "DSC_PLAYER_USER_AVATAR_URL" VARCHAR(500);
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                ALTER TABLE "LULM_PLAYER_USER"
+                    DROP COLUMN IF EXISTS "DSC_PLAYER_USER_AVATAR_URL";
+
+                ALTER TABLE "LULM_PLAYER_USER"
+                    DROP COLUMN IF EXISTS "DSC_PLAYER_USER_BIO";
+                """);
+        }
+    }
+}

--- a/Models/PlayerUser.cs
+++ b/Models/PlayerUser.cs
@@ -12,6 +12,8 @@ public class PlayerUser{
   public DateTime? LastLogin { get; set; }
   public DateTime CreationDate { get; set; }
   public bool IsActive { get; set; }
+  public string? Bio { get; set; }
+  public string? AvatarUrl { get; set; }
 
   public PlayerUser(){
     this.Id = 0;

--- a/Program.cs
+++ b/Program.cs
@@ -93,6 +93,14 @@ builder.Services.Configure<LevelUpLifeBackend.Infrastructure.Configuration.Level
 
 builder.Services.AddSingleton<ILevelProgressService, LevelProgressService>();
 
+builder.Services.Configure<LevelUpLifeBackend.Infrastructure.Configuration.PlayerProfileOptions>(
+    builder.Configuration.GetSection(
+        LevelUpLifeBackend.Infrastructure.Configuration.PlayerProfileOptions.SectionName
+    )
+);
+
+builder.Services.AddScoped<IAvatarStorageService, LocalAvatarStorageService>();
+
 // Services and Repositories of Habit Category
 builder.Services.AddScoped<IHabitCategoryRepository, HabitCategoryRepository>();
 builder.Services.AddScoped<IHabitCategoryService, HabitCategoryService>();
@@ -156,6 +164,11 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 
 var app = builder.Build();
 
+var avatarStoragePath = Path.Combine(
+    app.Environment.ContentRootPath,
+    builder.Configuration.GetSection("PlayerProfile:AvatarStoragePath").Value ?? "uploads/avatars");
+Directory.CreateDirectory(avatarStoragePath);
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
@@ -164,6 +177,13 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new Microsoft.Extensions.FileProviders.PhysicalFileProvider(
+        Path.Combine(app.Environment.ContentRootPath, "uploads")),
+    RequestPath = "/uploads",
+});
 
 // IMPORTANTE: Authentication va ANTES que Authorization.
 app.UseAuthentication();

--- a/Program.cs
+++ b/Program.cs
@@ -85,6 +85,14 @@ builder.Services.Configure<LevelUpLifeBackend.Infrastructure.Configuration.Strea
     )
 );
 
+builder.Services.Configure<LevelUpLifeBackend.Infrastructure.Configuration.LevelingOptions>(
+    builder.Configuration.GetSection(
+        LevelUpLifeBackend.Infrastructure.Configuration.LevelingOptions.SectionName
+    )
+);
+
+builder.Services.AddSingleton<ILevelProgressService, LevelProgressService>();
+
 // Services and Repositories of Habit Category
 builder.Services.AddScoped<IHabitCategoryRepository, HabitCategoryRepository>();
 builder.Services.AddScoped<IHabitCategoryService, HabitCategoryService>();

--- a/Services/AuthService.cs
+++ b/Services/AuthService.cs
@@ -12,11 +12,16 @@ namespace LevelUpLifeBackend.Services;
 public class AuthService : IAuthService
 {
     private readonly IAuthRepository _authRepository;
+    private readonly ILevelProgressService _levelProgressService;
     private readonly IConfiguration _configuration;
 
-    public AuthService(IAuthRepository authRepository, IConfiguration configuration)
+    public AuthService(
+        IAuthRepository authRepository,
+        ILevelProgressService levelProgressService,
+        IConfiguration configuration)
     {
         _authRepository = authRepository;
+        _levelProgressService = levelProgressService;
         _configuration = configuration;
     }
 
@@ -61,12 +66,16 @@ public class AuthService : IAuthService
         if (!BCrypt.Net.BCrypt.Verify(request.Password, user.Password))
             return null;
         var token = GenerateJwtToken(user.Id, user.UserName);
+        var levelProgress = _levelProgressService.GetLevelProgress(user.ExperiencePoints);
+
         return new LoginResponseDto
         {
             Token = token,
             UserName = user.UserName,
-            Level = user.Level,
-            ClassName = user.Class?.Name ?? string.Empty
+            Level = levelProgress.CurrentLevel,
+            ClassName = user.Class?.Name ?? string.Empty,
+            LevelProgress = levelProgress,
+            LevelingConfig = _levelProgressService.GetLevelingConfig(),
         };
     }
 

--- a/Services/HabitService.cs
+++ b/Services/HabitService.cs
@@ -16,6 +16,7 @@ public class HabitService : IHabitService
     private readonly IRepetitionCriteriaRepository _repetitionCriteriaRepository;
     private readonly ITimerCriteriaRepository _timerCriteriaRepository;
     private readonly IStreakLogRepository _streakLogRepository;
+    private readonly ILevelProgressService _levelProgressService;
     private readonly AppDbContext _context;
 
     public HabitService(
@@ -24,6 +25,7 @@ public class HabitService : IHabitService
         IRepetitionCriteriaRepository repetitionCriteriaRepository,
         ITimerCriteriaRepository timerCriteriaRepository,
         IStreakLogRepository streakLogRepository,
+        ILevelProgressService levelProgressService,
         AppDbContext context)
     {
         _habitRepository = habitRepository;
@@ -31,6 +33,7 @@ public class HabitService : IHabitService
         _repetitionCriteriaRepository = repetitionCriteriaRepository;
         _timerCriteriaRepository = timerCriteriaRepository;
         _streakLogRepository = streakLogRepository;
+        _levelProgressService = levelProgressService;
         _context = context;
     }
 
@@ -310,9 +313,9 @@ public class HabitService : IHabitService
 
         task.IsCompleted = true;
         task.EarnedXpSnapshot = xpEarned;
-        var previousLevel = player.Level;
+        var previousLevel = _levelProgressService.CalculateLevel(player.ExperiencePoints);
         player.ExperiencePoints += xpEarned;
-        player.Level = PlayerProgressMapper.CalculateLevel(player.ExperiencePoints);
+        player.Level = _levelProgressService.CalculateLevel(player.ExperiencePoints);
 
         var streakResult = await ApplyStreakUpdateAsync(player, completionDate);
         var completionEvents = BuildCompletionEvents(
@@ -325,7 +328,12 @@ public class HabitService : IHabitService
 
         await _habitTaskRepository.CompleteTaskAsync(task, streakResult.Log, completionEvents);
 
-        return PlayerProgressMapper.ToCompleteResponse(xpEarned, player.Level, streakResult.Updated);
+        return _levelProgressService.ToCompleteResponse(
+            xpEarned,
+            previousLevel,
+            player.ExperiencePoints,
+            streakResult.Updated,
+            player.DaysStreak);
     }
 
     private static IReadOnlyList<PlayerEvent> BuildCompletionEvents(

--- a/Services/IAvatarStorageService.cs
+++ b/Services/IAvatarStorageService.cs
@@ -1,0 +1,8 @@
+namespace LevelUpLifeBackend.Services;
+
+public interface IAvatarStorageService
+{
+    Task<string> SaveAvatarAsync(int playerUserId, Stream content, string contentType, string fileExtension);
+
+    Task DeleteAvatarIfExistsAsync(string? avatarUrl);
+}

--- a/Services/ILevelProgressService.cs
+++ b/Services/ILevelProgressService.cs
@@ -1,0 +1,23 @@
+using LevelUpLifeBackend.DTOs.Responses;
+
+namespace LevelUpLifeBackend.Services;
+
+public interface ILevelProgressService
+{
+    int GetXpRequiredForLevel(int level);
+
+    int GetTotalXpForLevel(int level);
+
+    int CalculateLevel(int totalExperiencePoints);
+
+    LevelProgressDto GetLevelProgress(int totalExperiencePoints);
+
+    LevelingConfigDto GetLevelingConfig();
+
+    CompleteHabitTaskResponseDto ToCompleteResponse(
+        int xpEarned,
+        int previousLevel,
+        int totalExperiencePoints,
+        bool streakUpdated,
+        int daysStreak);
+}

--- a/Services/IPlayerService.cs
+++ b/Services/IPlayerService.cs
@@ -14,6 +14,13 @@ public interface IPlayerService
     );
 
     Task<DeletePlayerAccountServiceResult> DeleteAccountAsync(int playerUserId, string? reason);
+
+    Task<UploadPlayerAvatarServiceResult> UploadAvatarAsync(
+        int playerUserId,
+        string ifMatchHeader,
+        Stream avatarContent,
+        string contentType,
+        long contentLength);
 }
 
 public enum GetPlayerProfileStatus
@@ -57,4 +64,20 @@ public class DeletePlayerAccountServiceResult
 {
     public DeletePlayerAccountStatus Status { get; set; }
     public DeletePlayerAccountResponseDto? Response { get; set; }
+}
+
+public enum UploadPlayerAvatarStatus
+{
+    Success,
+    NotFound,
+    ETagMismatch,
+    InvalidData,
+}
+
+public class UploadPlayerAvatarServiceResult
+{
+    public UploadPlayerAvatarStatus Status { get; set; }
+    public UpdatePlayerProfileResponseDto? Response { get; set; }
+    public string? ETag { get; set; }
+    public string? Details { get; set; }
 }

--- a/Services/LevelProgressService.cs
+++ b/Services/LevelProgressService.cs
@@ -1,0 +1,136 @@
+using LevelUpLifeBackend.DTOs.Responses;
+using LevelUpLifeBackend.Infrastructure.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace LevelUpLifeBackend.Services;
+
+public class LevelProgressService : ILevelProgressService
+{
+    private readonly LevelingOptions _options;
+
+    public LevelProgressService(IOptions<LevelingOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public int GetXpRequiredForLevel(int level)
+    {
+        EnsureSupportedStrategy();
+
+        if (level < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(level), "Level must be at least 1.");
+        }
+
+        if (level == 1)
+        {
+            return _options.BaseXpPerLevel;
+        }
+
+        var escalationFactor = 1.0 + (_options.EscalationPercent / 100.0);
+        return (int)Math.Round(_options.BaseXpPerLevel * Math.Pow(escalationFactor, level - 2));
+    }
+
+    public int GetTotalXpForLevel(int level)
+    {
+        if (level <= 1)
+        {
+            return 0;
+        }
+
+        var total = 0;
+        for (var currentLevel = 1; currentLevel < level; currentLevel++)
+        {
+            total += GetXpRequiredForLevel(currentLevel);
+        }
+
+        return total;
+    }
+
+    public int CalculateLevel(int totalExperiencePoints)
+    {
+        var totalXp = Math.Max(0, totalExperiencePoints);
+        var level = 1;
+
+        while (GetTotalXpForLevel(level + 1) <= totalXp)
+        {
+            level++;
+        }
+
+        return level;
+    }
+
+    public LevelProgressDto GetLevelProgress(int totalExperiencePoints)
+    {
+        var totalXp = Math.Max(0, totalExperiencePoints);
+        var currentLevel = CalculateLevel(totalXp);
+        var xpAtLevelStart = GetTotalXpForLevel(currentLevel);
+        var xpInCurrentLevel = totalXp - xpAtLevelStart;
+        var xpRequiredForNextLevel = GetXpRequiredForLevel(currentLevel);
+        var progressPercent = xpRequiredForNextLevel > 0
+            ? Math.Min(1.0, (double)xpInCurrentLevel / xpRequiredForNextLevel)
+            : 1.0;
+
+        return new LevelProgressDto
+        {
+            CurrentLevel = currentLevel,
+            TotalExperiencePoints = totalXp,
+            ExperiencePointsInCurrentLevel = xpInCurrentLevel,
+            ExperiencePointsRequiredForNextLevel = xpRequiredForNextLevel,
+            LevelProgressPercent = Math.Round(progressPercent, 4),
+        };
+    }
+
+    public LevelingConfigDto GetLevelingConfig()
+    {
+        return new LevelingConfigDto
+        {
+            Strategy = MapStrategyToApiValue(_options.Strategy),
+            BaseXpPerLevel = _options.BaseXpPerLevel,
+            EscalationPercent = _options.EscalationPercent,
+        };
+    }
+
+    public CompleteHabitTaskResponseDto ToCompleteResponse(
+        int xpEarned,
+        int previousLevel,
+        int totalExperiencePoints,
+        bool streakUpdated,
+        int daysStreak)
+    {
+        var progress = GetLevelProgress(totalExperiencePoints);
+        var newLevel = progress.CurrentLevel;
+
+        return new CompleteHabitTaskResponseDto
+        {
+            XpEarned = xpEarned,
+            PreviousLevel = previousLevel,
+            NewLevel = newLevel,
+            TotalExperiencePoints = progress.TotalExperiencePoints,
+            ExperiencePointsInCurrentLevel = progress.ExperiencePointsInCurrentLevel,
+            ExperiencePointsRequiredForNextLevel = progress.ExperiencePointsRequiredForNextLevel,
+            LevelProgressPercent = progress.LevelProgressPercent,
+            LeveledUp = newLevel > previousLevel,
+            StreakUpdated = streakUpdated,
+            DaysStreak = daysStreak,
+            LevelingConfig = GetLevelingConfig(),
+        };
+    }
+
+    private void EnsureSupportedStrategy()
+    {
+        if (_options.Strategy != LevelingStrategy.EscalatingPercent)
+        {
+            throw new NotSupportedException(
+                $"Leveling strategy '{_options.Strategy}' is not implemented yet."
+            );
+        }
+    }
+
+    private static string MapStrategyToApiValue(LevelingStrategy strategy) =>
+        strategy switch
+        {
+            LevelingStrategy.EscalatingPercent => "escalating_percent",
+            _ => strategy.ToString().ToLowerInvariant(),
+        };
+}

--- a/Services/LocalAvatarStorageService.cs
+++ b/Services/LocalAvatarStorageService.cs
@@ -1,0 +1,70 @@
+using LevelUpLifeBackend.Infrastructure.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace LevelUpLifeBackend.Services;
+
+public class LocalAvatarStorageService : IAvatarStorageService
+{
+    private readonly PlayerProfileOptions _options;
+    private readonly IWebHostEnvironment _environment;
+
+    public LocalAvatarStorageService(
+        IOptions<PlayerProfileOptions> options,
+        IWebHostEnvironment environment)
+    {
+        _options = options.Value;
+        _environment = environment;
+    }
+
+    public async Task<string> SaveAvatarAsync(
+        int playerUserId,
+        Stream content,
+        string contentType,
+        string fileExtension)
+    {
+        var playerDirectory = Path.Combine(
+            _environment.ContentRootPath,
+            _options.AvatarStoragePath,
+            playerUserId.ToString());
+
+        Directory.CreateDirectory(playerDirectory);
+
+        foreach (var existingFile in Directory.EnumerateFiles(playerDirectory))
+        {
+            File.Delete(existingFile);
+        }
+
+        var fileName = $"{Guid.NewGuid():N}{fileExtension}";
+        var absolutePath = Path.Combine(playerDirectory, fileName);
+
+        await using var fileStream = File.Create(absolutePath);
+        await content.CopyToAsync(fileStream);
+
+        var publicUrl = $"{_options.AvatarPublicBasePath.TrimEnd('/')}/{playerUserId}/{fileName}";
+        return publicUrl;
+    }
+
+    public Task DeleteAvatarIfExistsAsync(string? avatarUrl)
+    {
+        if (string.IsNullOrWhiteSpace(avatarUrl))
+        {
+            return Task.CompletedTask;
+        }
+
+        var relativePath = avatarUrl
+            .Replace(_options.AvatarPublicBasePath.TrimEnd('/'), string.Empty, StringComparison.OrdinalIgnoreCase)
+            .TrimStart('/');
+
+        var absolutePath = Path.Combine(
+            _environment.ContentRootPath,
+            _options.AvatarStoragePath,
+            relativePath.Replace('/', Path.DirectorySeparatorChar));
+
+        if (File.Exists(absolutePath))
+        {
+            File.Delete(absolutePath);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/Services/PlayerService.cs
+++ b/Services/PlayerService.cs
@@ -10,10 +10,14 @@ namespace LevelUpLifeBackend.Services;
 public class PlayerService : IPlayerService
 {
     private readonly IPlayerRepository _playerRepository;
+    private readonly ILevelProgressService _levelProgressService;
 
-    public PlayerService(IPlayerRepository playerRepository)
+    public PlayerService(
+        IPlayerRepository playerRepository,
+        ILevelProgressService levelProgressService)
     {
         _playerRepository = playerRepository;
+        _levelProgressService = levelProgressService;
     }
 
     public async Task<GetPlayerProfileServiceResult> GetProfileAsync(int playerUserId)
@@ -165,15 +169,22 @@ public class PlayerService : IPlayerService
     private static DateTime? NormalizeLastLogin(DateTime? lastLogin) =>
         lastLogin is { Year: > 1 } ? lastLogin : null;
 
-    private static GetPlayerProfileResponseDto MapToGetProfileResponse(PlayerUser player)
+    private GetPlayerProfileResponseDto MapToGetProfileResponse(PlayerUser player)
     {
+        var levelProgress = _levelProgressService.GetLevelProgress(player.ExperiencePoints);
+
         return new GetPlayerProfileResponseDto
         {
             PlayerUserId = player.Id.ToString(),
             PlayerUserUserName = player.UserName,
-            PlayerUserLevel = player.Level,
+            PlayerUserLevel = levelProgress.CurrentLevel,
             StatusIsActive = player.IsActive,
             PlayerUserLastLogin = NormalizeLastLogin(player.LastLogin),
+            TotalExperiencePoints = levelProgress.TotalExperiencePoints,
+            ExperiencePointsInCurrentLevel = levelProgress.ExperiencePointsInCurrentLevel,
+            ExperiencePointsRequiredForNextLevel = levelProgress.ExperiencePointsRequiredForNextLevel,
+            LevelProgressPercent = levelProgress.LevelProgressPercent,
+            LevelingConfig = _levelProgressService.GetLevelingConfig(),
             PersonData = new GetPlayerProfilePersonDataDto
             {
                 Name = player.Person.Name,

--- a/Services/PlayerService.cs
+++ b/Services/PlayerService.cs
@@ -2,8 +2,11 @@ using System.Security.Cryptography;
 using System.Text;
 using LevelUpLifeBackend.DTOs.Requests;
 using LevelUpLifeBackend.DTOs.Responses;
+using LevelUpLifeBackend.Infrastructure;
+using LevelUpLifeBackend.Infrastructure.Configuration;
 using LevelUpLifeBackend.Models;
 using LevelUpLifeBackend.Repositories;
+using Microsoft.Extensions.Options;
 
 namespace LevelUpLifeBackend.Services;
 
@@ -11,13 +14,19 @@ public class PlayerService : IPlayerService
 {
     private readonly IPlayerRepository _playerRepository;
     private readonly ILevelProgressService _levelProgressService;
+    private readonly IAvatarStorageService _avatarStorageService;
+    private readonly PlayerProfileOptions _profileOptions;
 
     public PlayerService(
         IPlayerRepository playerRepository,
-        ILevelProgressService levelProgressService)
+        ILevelProgressService levelProgressService,
+        IAvatarStorageService avatarStorageService,
+        IOptions<PlayerProfileOptions> profileOptions)
     {
         _playerRepository = playerRepository;
         _levelProgressService = levelProgressService;
+        _avatarStorageService = avatarStorageService;
+        _profileOptions = profileOptions.Value;
     }
 
     public async Task<GetPlayerProfileServiceResult> GetProfileAsync(int playerUserId)
@@ -97,6 +106,21 @@ public class PlayerService : IPlayerService
             player.Class = selectedClass;
         }
 
+        if (request.PlayerData?.Bio is not null)
+        {
+            var bio = request.PlayerData.Bio.Trim();
+            if (bio.Length > _profileOptions.MaxBioLength)
+            {
+                return new UpdatePlayerProfileServiceResult
+                {
+                    Status = UpdatePlayerProfileStatus.InvalidData,
+                    Details = $"La bio no puede superar {_profileOptions.MaxBioLength} caracteres."
+                };
+            }
+
+            player.Bio = bio.Length == 0 ? null : bio;
+        }
+
         if (request.PersonData is not null)
         {
             if (request.PersonData.Name is not null)
@@ -126,6 +150,82 @@ public class PlayerService : IPlayerService
         };
     }
 
+    public async Task<UploadPlayerAvatarServiceResult> UploadAvatarAsync(
+        int playerUserId,
+        string ifMatchHeader,
+        Stream avatarContent,
+        string contentType,
+        long contentLength)
+    {
+        var player = await _playerRepository.GetActiveByIdWithRelationsAsync(playerUserId);
+        if (player is null)
+        {
+            return new UploadPlayerAvatarServiceResult { Status = UploadPlayerAvatarStatus.NotFound };
+        }
+
+        var currentETag = GenerateETag(player);
+        if (!ETagMatches(ifMatchHeader, currentETag))
+        {
+            return new UploadPlayerAvatarServiceResult
+            {
+                Status = UploadPlayerAvatarStatus.ETagMismatch,
+                ETag = currentETag
+            };
+        }
+
+        if (contentLength <= 0)
+        {
+            return InvalidAvatarUpload("Debe enviar un archivo de imagen.");
+        }
+
+        if (contentLength > _profileOptions.MaxAvatarBytes)
+        {
+            return InvalidAvatarUpload(
+                $"La imagen supera el tamaño máximo permitido ({_profileOptions.MaxAvatarBytes} bytes).");
+        }
+
+        if (!AvatarContentTypeValidator.IsAllowedContentType(
+                contentType,
+                _profileOptions.AllowedAvatarContentTypes))
+        {
+            return InvalidAvatarUpload(
+                "Tipo de imagen no permitido. Use JPEG, PNG o WEBP.");
+        }
+
+        if (!AvatarContentTypeValidator.HasValidSignature(avatarContent, contentType))
+        {
+            return InvalidAvatarUpload("El contenido del archivo no coincide con el tipo declarado.");
+        }
+
+        var extension = AvatarContentTypeValidator.ResolveExtension(contentType);
+        if (string.IsNullOrEmpty(extension))
+        {
+            return InvalidAvatarUpload("Tipo de imagen no permitido. Use JPEG, PNG o WEBP.");
+        }
+
+        await _avatarStorageService.DeleteAvatarIfExistsAsync(player.AvatarUrl);
+        var avatarUrl = await _avatarStorageService.SaveAvatarAsync(
+            playerUserId,
+            avatarContent,
+            contentType,
+            extension);
+
+        player.AvatarUrl = avatarUrl;
+        await _playerRepository.SaveChangesAsync();
+
+        return new UploadPlayerAvatarServiceResult
+        {
+            Status = UploadPlayerAvatarStatus.Success,
+            Response = new UpdatePlayerProfileResponseDto
+            {
+                Success = true,
+                Message = "Avatar actualizado correctamente",
+                Player = MapToProfileDto(player)
+            },
+            ETag = GenerateETag(player)
+        };
+    }
+
     public async Task<DeletePlayerAccountServiceResult> DeleteAccountAsync(int playerUserId, string? reason)
     {
         var player = await _playerRepository.GetByIdWithRelationsAsync(playerUserId);
@@ -137,7 +237,6 @@ public class PlayerService : IPlayerService
             };
         }
 
-        // Si la cuenta ya está inactiva, rechazamos la operación.
         if (!player.IsActive)
         {
             return new DeletePlayerAccountServiceResult
@@ -166,6 +265,13 @@ public class PlayerService : IPlayerService
         };
     }
 
+    private UploadPlayerAvatarServiceResult InvalidAvatarUpload(string details) =>
+        new()
+        {
+            Status = UploadPlayerAvatarStatus.InvalidData,
+            Details = details,
+        };
+
     private static DateTime? NormalizeLastLogin(DateTime? lastLogin) =>
         lastLogin is { Year: > 1 } ? lastLogin : null;
 
@@ -180,6 +286,9 @@ public class PlayerService : IPlayerService
             PlayerUserLevel = levelProgress.CurrentLevel,
             StatusIsActive = player.IsActive,
             PlayerUserLastLogin = NormalizeLastLogin(player.LastLogin),
+            PlayerUserCreationDate = player.CreationDate,
+            Bio = player.Bio,
+            AvatarUrl = player.AvatarUrl,
             TotalExperiencePoints = levelProgress.TotalExperiencePoints,
             ExperiencePointsInCurrentLevel = levelProgress.ExperiencePointsInCurrentLevel,
             ExperiencePointsRequiredForNextLevel = levelProgress.ExperiencePointsRequiredForNextLevel,
@@ -195,17 +304,22 @@ public class PlayerService : IPlayerService
         };
     }
 
-    private static PlayerProfileDto MapToProfileDto(PlayerUser player)
+    private PlayerProfileDto MapToProfileDto(PlayerUser player)
     {
+        var levelProgress = _levelProgressService.GetLevelProgress(player.ExperiencePoints);
+
         return new PlayerProfileDto
         {
             Id = player.Id,
             UserName = player.UserName,
-            Level = player.Level,
+            Level = levelProgress.CurrentLevel,
             IsActive = player.IsActive,
             LastLogin = NormalizeLastLogin(player.LastLogin),
             ClassId = player.Class.Id,
             ClassName = player.Class.Name,
+            Bio = player.Bio,
+            AvatarUrl = player.AvatarUrl,
+            CreationDate = player.CreationDate,
             Person = new PersonProfileDto
             {
                 Id = player.Person.Id,
@@ -234,7 +348,10 @@ public class PlayerService : IPlayerService
             player.Person.LastName,
             player.Person.Email,
             player.Person.BirthDate?.ToString("yyyy-MM-dd") ?? "",
-            player.Person.IsActive
+            player.Person.IsActive,
+            player.Bio ?? "",
+            player.AvatarUrl ?? "",
+            player.CreationDate.ToUniversalTime().ToString("O")
         );
 
         var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(canonical));

--- a/docs/gamification-design-decisions.md
+++ b/docs/gamification-design-decisions.md
@@ -4,7 +4,7 @@ Documento de entrega para revisión de **Adam** (y QA). Describe la implementaci
 
 **Rama de trabajo:** `feature/29-habit-task-xp-and-streak` (basada en `dev` con #28 mergeado).
 
-**Estado tests:** `60/60` pasando (`dotnet test` en `LevelUpLife-Backend.Tests`).
+**Estado tests:** `68/68` pasando (`dotnet test` en `LevelUpLife-Backend.Tests`).
 
 **Fuera de alcance en esta rama:** Bloque D (claim de recompensas), seed de catálogo, `GET /api/player/events` — lo implementará el equipo de recompensas.
 
@@ -18,14 +18,14 @@ Documento de entrega para revisión de **Adam** (y QA). Describe la implementaci
 |----------|---------|
 | **Endpoint** | `PATCH /api/habit-tasks/{id}/complete` |
 | **Body** | `{ "completedAt": "<ISO 8601 UTC>" }` |
-| **200 OK** | `{ "xpEarned": int, "newLevel": int, "streakUpdated": bool }` |
+| **200 OK** | `{ "xpEarned", "previousLevel", "newLevel", "totalExperiencePoints", "experiencePointsInCurrentLevel", "experiencePointsRequiredForNextLevel", "levelProgressPercent", "leveledUp", "streakUpdated", "daysStreak", "levelingConfig" }` (campos legacy `xpEarned`, `newLevel`, `streakUpdated` se mantienen) |
 | **400** | `COMPLETION_REQUIREMENTS_NOT_MET` (`TaskError`) |
 | **404** | `TASK_NOT_FOUND` / hábito inactivo |
 | **500** | error genérico |
 
 Comportamientos #29 que siguen vigentes:
 
-- Completar otorga `xpEarned` y recalcula `newLevel` (`level = max(1, 1 + XP/100)`).
+- Completar otorga `xpEarned` y recalcula `newLevel` con **umbrales progresivos** (estrategia `EscalatingPercent`, ver §11).
 - No hay doble XP/racha al repetir la misma tarea → **400**.
 - `streakUpdated: true` solo en la **primera completion del día** (UTC); otras tareas del mismo día → `streakUpdated: false`.
 - La racha inicia en **1** (no en 0) y se persiste en `LULH_STREAK_LOG`.
@@ -363,22 +363,23 @@ Alineado con patrones #27–#28 (Adam):
 | Persistencia transaccional complete | `HabitTaskRepository.CompleteTaskAsync` (streak log + eventos en la misma transacción) |
 | Protección de racha | `StreakService` + `StreakController` (log + evento en la misma transacción) |
 | Eventos internos | `PlayerEventRepository` + registro desde `HabitService` / `StreakService` |
-| Mapeo XP/nivel/response | `PlayerProgressMapper` |
+| Mapeo XP/nivel/response | `LevelProgressService` + `PlayerProgressMapper` (XP/racha) |
 
 **Auth endpoints nuevos:** solo JWT (`[Authorize]` + `ResolveAuthenticatedUserId` desde claims). No `X-User-Id`.
 
-**Configuración:** `appsettings.json` → sección `StreakProtection:MaxPerMonth` (default 3).
+**Configuración:** `appsettings.json` → `StreakProtection:MaxPerMonth` (default 3), `Leveling` (issue #89).
 
 ---
 
-## 6. Suite de tests (60)
+## 6. Suite de tests (68)
 
 | Archivo | Qué cubre |
 |---------|-----------|
 | `HabitServiceUpdateTaskTests` | Complete #29, level-up, validaciones, PUT preserva completion |
 | `StreakCalculatorTests` | Gap 1 día, reinicio, salvavidas, hueco 4 días |
 | `StreakProtectionTypeParserTests` | Tipos válidos/inválidos de protección |
-| `PlayerProgressMapperTests` | XP por dificultad, nivel |
+| `LevelProgressServiceTests` | Umbrales progresivos, progreso parcial, complete response |
+| `PlayerProgressMapperTests` | XP por dificultad |
 
 Ejecutar:
 
@@ -488,7 +489,73 @@ Scripts/
 - Notificaciones push / recordatorios (solo datos en `LULH_PLAYER_EVENT`).
 - Tienda / gasto de oro (`CostGold`).
 - Panel admin, ranking, pagos, i18n, despliegue.
+- Estrategia Fibonacci para niveles (futuro; hoy solo `EscalatingPercent`).
 
 ---
 
-*Última actualización: eventos en transacción con complete/protection; validación de tipo de protección con envelope unificado; 60 tests.*
+## 11. Issue #89 — Umbrales progresivos de XP por nivel
+
+**Rama:** `feature/89-progressive-xp-leveling`  
+**Fuente de verdad:** `LevelProgressService` (backend). El frontend **no** debe duplicar la fórmula.
+
+### Estrategia configurada (`Leveling` en appsettings)
+
+| Setting | Default | Descripción |
+|---------|---------|-------------|
+| `Strategy` | `EscalatingPercent` | Estrategia activa |
+| `BaseXpPerLevel` | `100` | XP base del salto 1→2 (y 2→3) |
+| `EscalationPercent` | `20` | Incremento por tier desde el nivel 3 |
+
+**Fórmula tier** (XP para pasar de nivel `n` a `n+1`):
+
+```
+xpRequired(1) = baseXp
+xpRequired(n) = round(baseXp * (1 + escalationPercent/100)^(n-2))   para n >= 2
+```
+
+**Ejemplo** (`baseXp=100`, `escalation=20%`):
+
+| Desde nivel | Hacia nivel | XP del tier | XP acumulado mínimo |
+|-------------|-------------|-------------|---------------------|
+| 1 | 2 | 100 | 0 → 100 |
+| 2 | 3 | 100 | 100 → 200 |
+| 3 | 4 | 120 | 200 → 320 |
+| 4 | 5 | 144 | 320 → 464 |
+| 5 | 6 | 173 | 464 → 637 |
+
+### Respuesta extendida — `PATCH /api/habit-tasks/{id}/complete`
+
+Campos **aditivos** (compatibles hacia atrás con #29):
+
+```json
+{
+  "xpEarned": 10,
+  "previousLevel": 3,
+  "newLevel": 3,
+  "totalExperiencePoints": 285,
+  "experiencePointsInCurrentLevel": 85,
+  "experiencePointsRequiredForNextLevel": 120,
+  "levelProgressPercent": 0.7083,
+  "leveledUp": false,
+  "streakUpdated": true,
+  "daysStreak": 2,
+  "levelingConfig": {
+    "strategy": "escalating_percent",
+    "baseXpPerLevel": 100,
+    "escalationPercent": 20
+  }
+}
+```
+
+### Login y perfil
+
+- `POST /api/auth/login` → `data.levelProgress` + `data.levelingConfig`
+- `GET /api/player/profile` → campos de progreso en el tier actual
+
+### Jugadores existentes
+
+Al completar una tarea, `Level` se recalcula desde `ExperiencePoints` con la nueva fórmula (no la lineal `1 + XP/100`).
+
+---
+
+*Última actualización: issue #89 — umbrales progresivos de XP, progreso en complete/login/profile.*


### PR DESCRIPTION
# 📌 Pull Request

This PR delivers two related player-experience improvements:

1. **#89 — Progressive XP leveling:** Replaces the fixed linear formula (`1 + XP/100`) with configurable escalating thresholds and exposes full level progress in the complete-task API (and login/profile).
2. **Player profile persistence:** Moves `bio` and `avatarUrl` from frontend-only local storage to the backend as the single source of truth.

---

## #89 — Progressive XP leveling

### Problem
The frontend reward dialog needs real progress toward the next level. The old formula used a flat 100 XP per level, which made late-game progression feel the same as early game and caused incorrect level-up detection when the client guessed `previousLevel` from cache.

### Solution
- New `LevelProgressService` with **EscalatingPercent** strategy (configurable via `appsettings`).
- Default: base **100 XP** for levels 1→2 and 2→3; **+20%** per tier from level 3→4 onward.
- Backend is the **single source of truth** for level calculation and progress.

### API changes (backward compatible)

**`PATCH /api/habit-tasks/{id}/complete`** — additive fields on 200 OK:
- `previousLevel`, `leveledUp`
- `totalExperiencePoints`, `experiencePointsInCurrentLevel`, `experiencePointsRequiredForNextLevel`, `levelProgressPercent`
- `daysStreak`, `levelingConfig`
- Existing fields unchanged: `xpEarned`, `newLevel`, `streakUpdated`

**Also aligned:**
- `POST /api/auth/login` → `data.levelProgress`, `data.levelingConfig`
- `GET /api/player/profile` → XP progress fields in current tier

### Configuration (`appsettings`)
```json
"Leveling": {
  "Strategy": "EscalatingPercent",
  "BaseXpPerLevel": 100,
  "EscalationPercent": 20
}
```

### Example tier table (default config)
| From level | To level | Tier XP |
|------------|----------|---------|
| 1 | 2 | 100 |
| 2 | 3 | 100 |
| 3 | 4 | 120 |
| 4 | 5 | 144 |
| 5 | 6 | ~173 |

Existing players: `Level` is recalculated from `ExperiencePoints` on task completion.

---

## Player bio & avatar profile

### Problem
Bio and profile picture lived only on the device (local cache). They were lost on reinstall, did not sync across devices, and could not be used by future features (leaderboards, public profiles).

### Solution
- New DB columns on `LULM_PLAYER_USER`: `DSC_PLAYER_USER_BIO`, `DSC_PLAYER_USER_AVATAR_URL`
- **GET** `/api/player/profile` → returns `bio`, `avatarUrl`, `PlayerUserCreationDate`
- **PUT/PATCH** `/api/player/update` → persists `playerData.bio` (requires `If-Match` ETag)
- **POST** `/api/player/profile/avatar` → multipart upload (`file` field), requires JWT + `If-Match`
- Local file storage under `uploads/avatars/{userId}/`, served at `/uploads/avatars/...`
- Validations: bio max 500 chars; avatar max 5 MB; JPEG/PNG/WEBP only (MIME + magic-byte check)

### Security
- Profile endpoints are JWT-scoped to the authenticated user only — no endpoint to read another user's profile by ID.

---

## Migrations

| Migration | Content |
|-----------|---------|
| `20260618224129_AddPlayerProfileBioAndAvatar` | `DSC_PLAYER_USER_BIO`, `DSC_PLAYER_USER_AVATAR_URL` |

**Setup:**
```bash
docker start leveluplife-postgres
dotnet ef database update
```

---

## Tests

**73/73** passing (`dotnet test`)

| Area | Coverage |
|------|----------|
| `LevelProgressServiceTests` | Tier math, partial progress, level-up response |
| `HabitServiceUpdateTaskTests` | Complete with new progress fields |
| `PlayerProfilePersistenceTests` | Bio CRUD, avatar validation, GET mapping |

---

## What was NOT broken

- #29 complete contract: same route, errors (400/404), `streakUpdated` semantics
- Block E: XP snapshot on complete
- Gamification streak engine (blocks A/B)
- Existing profile fields (name, email, username, ETag flow)

---

## Test plan

### #89 — Leveling
- [ ] Complete task without level-up → `leveledUp: false`, correct `levelProgressPercent`
- [ ] Complete task with level-up → `previousLevel`, `newLevel`, `leveledUp: true`
- [ ] Second task same day → `streakUpdated: false` (regression)
- [ ] Double complete same task → 400 (regression)
- [ ] Login → `levelProgress` matches profile XP fields

### Profile — Bio & avatar
- [ ] `GET /api/player/profile` → `bio`, `avatarUrl` (nullable)
- [ ] `PUT /api/player/update` with `If-Match` → bio persisted
- [ ] Logout → login → bio unchanged
- [ ] `POST /api/player/profile/avatar` with valid image → `avatarUrl` returned; image loads at `/uploads/avatars/...`
- [ ] Invalid MIME / file too large → 400
- [ ] Missing or stale `If-Match` → 400 / 412

### Screenshots
<img width="1391" height="843" alt="image" src="https://github.com/user-attachments/assets/cefd3181-025e-4b2e-a70b-23f7f9b00b0d" />
<img width="1389" height="833" alt="image" src="https://github.com/user-attachments/assets/8f4f5664-3931-4334-9208-b6bd80e306c4" />
<img width="1389" height="830" alt="image" src="https://github.com/user-attachments/assets/ba40c550-4b09-4708-b546-60260dfe4296" />
<img width="1393" height="835" alt="image" src="https://github.com/user-attachments/assets/4fbb2598-c8bc-48b1-ad7a-33b482d0c715" />


---

## Deployment notes

- Run EF migration before deploy
- Ensure `uploads/avatars` directory is writable (or configure `PlayerProfile:AvatarStoragePath`)
- Optional: add `PlayerProfile` section to environment `appsettings` (defaults work out of the box)
- `uploads/` is gitignored — avatar files are runtime data, not in repo

---

## Related issues

- Closes #89
- Player bio/avatar backend (frontend local-storage workaround can be removed in separate FE PR)



