### PR TITLE
feat: expose daysStreak in player profile response

### DIFF
--- a/DTOs/Responses/GetPlayerProfileResponseDto.cs
+++ b/DTOs/Responses/GetPlayerProfileResponseDto.cs
@@ -25,6 +25,9 @@ public class GetPlayerProfileResponseDto
     [JsonPropertyName("levelProgressPercent")]
     public double LevelProgressPercent { get; set; }
 
+    [JsonPropertyName("daysStreak")]
+    public int DaysStreak { get; set; }
+
     [JsonPropertyName("levelingConfig")]
     public LevelingConfigDto LevelingConfig { get; set; } = new();
 

--- a/Services/PlayerService.cs
+++ b/Services/PlayerService.cs
@@ -293,6 +293,7 @@ public class PlayerService : IPlayerService
             ExperiencePointsInCurrentLevel = levelProgress.ExperiencePointsInCurrentLevel,
             ExperiencePointsRequiredForNextLevel = levelProgress.ExperiencePointsRequiredForNextLevel,
             LevelProgressPercent = levelProgress.LevelProgressPercent,
+            DaysStreak = player.DaysStreak,
             LevelingConfig = _levelProgressService.GetLevelingConfig(),
             PersonData = new GetPlayerProfilePersonDataDto
             {


### PR DESCRIPTION
## 📖 Description

Adds `daysStreak` to the `GET /api/player/profile` response so clients can read the player's current consecutive-day streak when loading the profile.

Changes:
- Add `daysStreak` property to `GetPlayerProfileResponseDto`
- Map `DaysStreak` from `PlayerUser` in `PlayerService`

---

## 🎯 Purpose

The Android home screen needs to display the streak on initial load. Previously, `daysStreak` was only returned when completing a habit task (`PATCH /api/habit-tasks/{id}/complete`), not when fetching the player profile.

This change exposes the existing streak value in the profile endpoint without requiring a separate call or task completion.

---

## 🔄 Type of Change

Please check the relevant option:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

Describe the tests you ran and how you verified your changes.

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

Explain the testing process:

- Logged in via Scalar with a valid JWT
- Called `GET /api/player/profile`
- Verified the response includes `daysStreak` with the expected value from the player record

---

## 📸 Screenshots (if applicable)

N/A — API response change only.

---

## 🚀 Deployment Notes (if needed)

No migration or config changes required. Deploy as a standard API update.

---

## ✅ Checklist

Before requesting a review, please confirm:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---
