### PR TITLE
Add DELETE /api/habits/{id} to soft-delete a habit. The habit and all of

### DIFF
--- a/Controllers/HabitController.cs
+++ b/Controllers/HabitController.cs
@@ -217,6 +217,51 @@ public class HabitsController : ControllerBase
         }
     }
 
+    // [Authorize] //
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> Deactivate(int id)
+    {
+        try
+        {
+            var userIdString = Request.Headers["X-User-Id"].FirstOrDefault();
+
+            if (string.IsNullOrEmpty(userIdString) || !int.TryParse(userIdString, out int userId))
+            {
+                return Unauthorized(new { success = false, message = "Acceso no autorizado." });
+            }
+
+            var deactivatedHabit = await _habitService.DeactivateHabitAsync(id, userId);
+
+            if (deactivatedHabit is null)
+            {
+                return NotFound(
+                    new { success = false, message = "El hábito que desea eliminar no existe." }
+                );
+            }
+
+            return Ok(
+                new
+                {
+                    success = true,
+                    message = "Hábito eliminado exitosamente!",
+                    data = deactivatedHabit,
+                }
+            );
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error al eliminar: {ex.Message}");
+            return StatusCode(
+                500,
+                new
+                {
+                    success = false,
+                    message = "Ocurrió un error inesperado al intentar eliminar el hábito.",
+                }
+            );
+        }
+    }
+
     private int? ResolveAuthenticatedUserId()
     {
         var userIdValue =

--- a/Services/HabitService.cs
+++ b/Services/HabitService.cs
@@ -633,4 +633,31 @@ public class HabitService : IHabitService
             throw;
         }
     }
+
+    public async Task<HabitResponseDto?> DeactivateHabitAsync(int habitId, int userId)
+    {
+        var habit = await _context.Habits
+            .Include(h => h.Discipline).ThenInclude(d => d.Category)
+            .Include(h => h.User)
+            .Include(h => h.Tasks)
+                .ThenInclude(t => t.RepetitionCriteria)
+            .Include(h => h.Tasks)
+                .ThenInclude(t => t.TimerCriteria)
+            .FirstOrDefaultAsync(h => h.Id == habitId && h.User.Id == userId);
+
+        if (habit is null || !habit.IsActive)
+        {
+            return null;
+        }
+
+        habit.IsActive = false;
+        foreach (var task in habit.Tasks)
+        {
+            task.IsActive = false;
+        }
+
+        await _habitRepository.UpdateHabitAsync(habit);
+
+        return HabitMapper.ToResponse(habit);
+    }
 }

--- a/Services/IHabitService.cs
+++ b/Services/IHabitService.cs
@@ -25,4 +25,5 @@ public interface IHabitService
         int userId
     );
     Task<HabitResponseDto?> UpdateHabitAsync(UpdateHabitRequestDto dto);
+    Task<HabitResponseDto?> DeactivateHabitAsync(int habitId, int userId);
 }


### PR DESCRIPTION
## 📖 Description   

  Adds a **soft delete** endpoint for habits: `DELETE /api/habits/{id}`. Deleting a
  habit deactivates it (`IsActive = false`) **and cascades the deactivation to all
  of its tasks**, so a "deleted" habit never leaves orphaned active tasks behind.
  The data is preserved in the database (soft delete), only flagged as inactive.

  ---

  ## 🎯 Purpose

  There was no way to remove a habit from the API — `HabitsController` only exposed
  GetById, Create, GetActive and Update. The Android client needs to let users
  delete a habit from the home screen. Since active habits/tasks are filtered by
  `IsActive`, deleting a habit must also deactivate its tasks; otherwise those
  tasks would remain active and orphaned. This PR adds that endpoint following the
  existing architecture (DTOs, Mappers, DI, Entity Framework) and mirrors the
  existing task-deactivation pattern (`DeactivateTaskAsync`).

  ---

  ## 🔄 Type of Change

  - [x] ✨ New feature
  - [ ] 🐛 Bug fix
  - [ ] ♻️ Refactor
  - [ ] 📝 Documentation update
  - [ ] ⚡ Performance improvement
  - [ ] 🔧 Other (please describe):

  ---

  ## 🧪 How Has This Been Tested?

  - [x] Manual testing
  - [ ] Unit tests
  - [ ] Integration tests

  Testing process:

  - `dotnet build` succeeds with **0 warnings / 0 errors**.
  - End-to-end from the Android client (LevelUpLife-Frontend):
    - Deleting a habit returns `200` and the habit disappears from the active list.
    - After deletion, the habit and **all of its tasks** are inactive
      (`IsActive = false`) — no task remains active.
    - Deleting a non-existent / already-inactive habit returns `404`.
    - A request without a valid `X-User-Id` header returns `401`.

  ---

  ## 📸 Screenshots (if applicable)

  N/A (API-only change).

  ---

  ## 🚀 Deployment Notes (if needed)

    `Habit` and `HabitTask`; no schema changes.
  - New endpoint: `DELETE /api/habits/{id}` (requires the `X-User-Id` header).

  ---
  
  ## ✅ Checklist
  
  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have tested my changes thoroughly
  ## ✅ Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have tested my changes thoroughly
  - [ ] I have updated documentation if necessary
  - [x] My changes do not introduce new warnings or errors

  ---

  ## 🧩 Related Issues

  Closes #13
  Linked to #13 