### PR TITLE
fix(habit-task): create timer criteria on update when switching to TIMER

### DIFF
--- a/Services/HabitService.cs
+++ b/Services/HabitService.cs
@@ -230,10 +230,16 @@ public class HabitService : IHabitService
         }
 
         if (request.CompletionCriteria == TaskCompletionCriteria.TIMER
-            && request.TimerCriteria is not null
-            && task.TimerCriteria is not null)
+            && request.TimerCriteria is not null)
         {
-            TimerCriteriaMapper.UpdateEntity(task.TimerCriteria, request.TimerCriteria);
+            if (task.TimerCriteria is null)
+            {
+                task.TimerCriteria = TimerCriteriaMapper.ToEntity(task.Id, request.TimerCriteria);
+            }
+            else
+            {
+                TimerCriteriaMapper.UpdateEntity(task.TimerCriteria, request.TimerCriteria);
+            }
         }
 
         await _habitTaskRepository.UpdateWithRepetitionCriteriaAsync(task);


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

This PR fixes an issue where `UpdateTaskAsync` only updated `TimerCriteria` if it already existed.
When switching a task from `REPETITIONS` to `TIMER`, no `TimerCriteria` was created, leaving the task without the required timer configuration.

Now, the logic ensures that when a task is updated to `TIMER`, a `TimerCriteria` is created if it does not exist, mirroring the behavior used for `REPETITIONS`.

---

## 🎯 Purpose

This PR solves an inconsistency when changing task types.

Previously:

* Tasks switched to `TIMER` could end up without a `TimerCriteria`.

Now:

* The system guarantees that a valid `TimerCriteria` always exists for `TIMER` tasks.

This change is necessary to maintain data integrity and consistent behavior across task types.

---

## 🔄 Type of Change

Please check the relevant option:

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] ♻️ Refactor
* [ ] 📝 Documentation update
* [ ] ⚡ Performance improvement
* [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

* [x] Manual testing
* [ ] Unit tests
* [ ] Integration tests

**Testing process:**

* Created a task with type `REPETITIONS`
* Updated the task to `TIMER`
* Verified that a `TimerCriteria` is automatically created
* Confirmed no duplicate records are created if one already exists
* Ensured existing flows for `REPETITIONS` remain unchanged

---

## 📸 Screenshots (if applicable)

N/A

---

## 🚀 Deployment Notes (if needed)

No special deployment steps required.

---

## ✅ Checklist

Before requesting a review, please confirm:

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have tested my changes thoroughly
* [ ] I have updated documentation if necessary
* [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #96 
Linked to #96 
