### PR TITLE
Rewards and effects

### DIFF
--- a/Controllers/RewardItemController.cs
+++ b/Controllers/RewardItemController.cs
@@ -68,6 +68,48 @@ public class RewardItemController : ControllerBase
         {
             return NotFound(ex.Payload);
         }
+        catch (InventoryError ex)
+        {
+            return StatusCode(ex.HttpStatusCode, ex.Payload);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new ErrorResponse
+            {
+                Code = 500,
+                Message = "An unexpected error occurred.",
+                Details = ex.Message
+            });
+        }
+    }
+
+    [HttpPost("inventory/{inventoryId:int}/activate")]
+    public async Task<IActionResult> Activate(int inventoryId)
+    {
+        var userId = ResolveUserId();
+        if (userId is null)
+        {
+            return Unauthorized(new
+            {
+                code = "UNAUTHORIZED",
+                message = "Unauthorized access.",
+                details = "A valid JWT or X-User-Id header is required.",
+            });
+        }
+
+        try
+        {
+            var result = await _inventoryService.ActivateAsync(userId.Value, inventoryId);
+            return Ok(result);
+        }
+        catch (NotFoundError ex)
+        {
+            return NotFound(ex.Payload);
+        }
+        catch (InventoryError ex)
+        {
+            return StatusCode(ex.HttpStatusCode, ex.Payload);
+        }
         catch (Exception ex)
         {
             return StatusCode(500, new ErrorResponse

--- a/DTOs/Responses/ActivateInventoryItemResponseDto.cs
+++ b/DTOs/Responses/ActivateInventoryItemResponseDto.cs
@@ -1,0 +1,8 @@
+namespace LevelUpLifeBackend.DTOs.Responses;
+
+public class ActivateInventoryItemResponseDto
+{
+    public PlayerInventoryResponseDto Inventory { get; set; } = new();
+    public PlayerActiveEffectResponseDto? ActiveEffect { get; set; }
+    public string? RecoveryMessage { get; set; }
+}

--- a/DTOs/Responses/PlayerActiveEffectResponseDto.cs
+++ b/DTOs/Responses/PlayerActiveEffectResponseDto.cs
@@ -1,17 +1,16 @@
 namespace LevelUpLifeBackend.DTOs.Responses;
 
-public class PlayerInventoryResponseDto
+public class PlayerActiveEffectResponseDto
 {
     public int Id { get; set; }
-    public int PlayerUserId { get; set; }
+    public int InventoryId { get; set; }
     public int RewardItemId { get; set; }
     public string RewardItemName { get; set; } = string.Empty;
     public int RewardItemTypeId { get; set; }
     public string RewardItemTypeName { get; set; } = string.Empty;
-    public int CostGold { get; set; }
     public decimal? EffectValue { get; set; }
-    public int? DurationDays { get; set; }
-    public int Quantity { get; set; }
-    public bool IsEquipped { get; set; }
-    public DateTime AcquiredAt { get; set; }
+    public int? RemainingCharges { get; set; }
+    public DateTime ActivatedAt { get; set; }
+    public DateTime? ExpiresAt { get; set; }
+    public bool IsActive { get; set; }
 }

--- a/DTOs/Responses/PlayerInventoryListResponseDto.cs
+++ b/DTOs/Responses/PlayerInventoryListResponseDto.cs
@@ -1,0 +1,7 @@
+namespace LevelUpLifeBackend.DTOs.Responses;
+
+public class PlayerInventoryListResponseDto
+{
+    public IEnumerable<PlayerInventoryResponseDto> Items { get; set; } = [];
+    public IEnumerable<PlayerActiveEffectResponseDto> ActiveEffects { get; set; } = [];
+}

--- a/DTOs/Responses/PurchaseRewardItemResponseDto.cs
+++ b/DTOs/Responses/PurchaseRewardItemResponseDto.cs
@@ -1,0 +1,7 @@
+namespace LevelUpLifeBackend.DTOs.Responses;
+
+public class PurchaseRewardItemResponseDto
+{
+    public PlayerInventoryResponseDto Inventory { get; set; } = new();
+    public int RemainingGold { get; set; }
+}

--- a/DTOs/Responses/RewardItemResponseDto.cs
+++ b/DTOs/Responses/RewardItemResponseDto.cs
@@ -9,5 +9,6 @@ public class RewardItemResponseDto
     public string? Description { get; set; }
     public int CostGold { get; set; }
     public decimal? EffectValue { get; set; }
+    public int? DurationDays { get; set; }
     public bool IsActive { get; set; }
 }

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -28,6 +28,7 @@ public class AppDbContext : DbContext
     public DbSet<StreakLog> StreakLogs { get; set; }
     public DbSet<PlayerEvent> PlayerEvents { get; set; }
     public DbSet<PlayerInventory> PlayerInventories { get; set; }
+    public DbSet<PlayerActiveEffect> PlayerActiveEffects { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -271,6 +272,7 @@ public class AppDbContext : DbContext
             entity.Property(e => e.Description).HasColumnName("DSC_REWARD_ITEM_DESCRIPTION");
             entity.Property(e => e.CostGold).HasColumnName("NUM_REWARD_ITEM_COST_GOLD");
             entity.Property(e => e.EffectValue).HasColumnName("NUM_REWARD_ITEM_EFFECT_VALUE");
+            entity.Property(e => e.DurationDays).HasColumnName("NUM_EFFECT_DURATION_DAYS");
             entity.Property(e => e.IsActive).HasColumnName("STATUS_REWARD_ITEM_IS_ACTIVE");
         });
 
@@ -342,6 +344,41 @@ public class AppDbContext : DbContext
 
             entity.HasIndex(e => e.PlayerUserId);
             entity.HasIndex(e => e.RewardItemId);
+        });
+
+        modelBuilder.Entity<PlayerActiveEffect>(entity =>
+        {
+            entity.ToTable("LULT_PLAYER_ACTIVE_EFFECT");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasColumnName("ID_PLAYER_ACTIVE_EFFECT");
+
+            entity.Property(e => e.PlayerUserId).HasColumnName("ID_PLAYER_USER");
+            entity.HasOne(e => e.PlayerUser)
+                .WithMany()
+                .HasForeignKey(e => e.PlayerUserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.Property(e => e.InventoryId).HasColumnName("ID_INVENTORY");
+            entity.HasOne(e => e.Inventory)
+                .WithMany()
+                .HasForeignKey(e => e.InventoryId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.Property(e => e.RewardItemId).HasColumnName("ID_REWARD_ITEM");
+            entity.HasOne(e => e.RewardItem)
+                .WithMany()
+                .HasForeignKey(e => e.RewardItemId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.Property(e => e.RewardItemTypeId).HasColumnName("ID_REWARD_ITEM_TYPE");
+            entity.Property(e => e.EffectValue).HasColumnName("NUM_EFFECT_VALUE");
+            entity.Property(e => e.RemainingCharges).HasColumnName("NUM_REMAINING_CHARGES");
+            entity.Property(e => e.ActivatedAt).HasColumnName("FEC_ACTIVATED");
+            entity.Property(e => e.ExpiresAt).HasColumnName("FEC_EXPIRES_AT");
+            entity.Property(e => e.IsActive).HasColumnName("STATUS_IS_ACTIVE");
+
+            entity.HasIndex(e => e.PlayerUserId);
+            entity.HasIndex(e => e.InventoryId);
         });
     }
 }

--- a/Infrastructure/Errors/InventoryError.cs
+++ b/Infrastructure/Errors/InventoryError.cs
@@ -1,0 +1,20 @@
+namespace LevelUpLifeBackend.Infrastructure.Errors;
+
+public enum InventoryFailureKind
+{
+    InsufficientGold,
+    ItemNotActivatable,
+    NoRecoveryTarget,
+    EffectAlreadyActive,
+}
+
+public sealed class InventoryError : AppError
+{
+    public InventoryFailureKind Kind { get; }
+
+    public InventoryError(ErrorResponse payload, InventoryFailureKind kind)
+        : base(payload.Code, payload, payload.Message)
+    {
+        Kind = kind;
+    }
+}

--- a/Infrastructure/RewardItemTypeIds.cs
+++ b/Infrastructure/RewardItemTypeIds.cs
@@ -1,0 +1,9 @@
+namespace LevelUpLifeBackend.Infrastructure;
+
+public static class RewardItemTypeIds
+{
+    public const int StreakProtection = 1;
+    public const int XpBoost = 2;
+    public const int HabitExpansion = 3;
+    public const int Recovery = 4;
+}

--- a/LevelUpLife-Backend.Tests/HabitServiceUpdateTaskTests.cs
+++ b/LevelUpLife-Backend.Tests/HabitServiceUpdateTaskTests.cs
@@ -44,6 +44,16 @@ public class HabitServiceUpdateTaskTests
         var criteriaRepo = new Mock<IRepetitionCriteriaRepository>();
         var timerRepo = new Mock<ITimerCriteriaRepository>();
         var streakLogRepo = streakRepo ?? CreateDefaultStreakRepoMock();
+        var effectService = new Mock<IPlayerEffectService>();
+        effectService
+            .Setup(s => s.GetActiveXpMultiplierAsync(It.IsAny<int>()))
+            .ReturnsAsync(1m);
+        effectService
+            .Setup(s => s.DeactivateExpiredEffectsAsync(It.IsAny<int>()))
+            .Returns(Task.CompletedTask);
+        effectService
+            .Setup(s => s.TryConsumeStreakShieldAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(false);
 
         return new HabitService(
             habitRepo.Object,
@@ -52,6 +62,7 @@ public class HabitServiceUpdateTaskTests
             timerRepo.Object,
             streakLogRepo.Object,
             CreateLevelProgressService(),
+            effectService.Object,
             context
         );
     }

--- a/LevelUpLife-Backend.Tests/PlayerEffectServiceTests.cs
+++ b/LevelUpLife-Backend.Tests/PlayerEffectServiceTests.cs
@@ -1,0 +1,277 @@
+using LevelUpLifeBackend.Data;
+using LevelUpLifeBackend.DTOs.Requests;
+using LevelUpLifeBackend.Infrastructure;
+using LevelUpLifeBackend.Infrastructure.Configuration;
+using LevelUpLifeBackend.Models;
+using LevelUpLifeBackend.Repositories;
+using LevelUpLifeBackend.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace LevelUpLife_Backend.Tests;
+
+public class PlayerEffectServiceTests
+{
+    [Theory]
+    [InlineData(100, 25)]
+    [InlineData(500, 50)]
+    public void CalculateXpPenalty_UsesTenPercentWithMinimum(int currentXp, int expectedPenalty)
+    {
+        var service = new PlayerEffectService(CreateContext());
+        Assert.Equal(expectedPenalty, service.CalculateXpPenalty(currentXp));
+    }
+
+    [Fact]
+    public async Task GetActiveXpMultiplierAsync_ReturnsHighestActiveBoost()
+    {
+        var context = CreateContext();
+        var player = await SeedPlayerAsync(context);
+        context.PlayerActiveEffects.AddRange(
+            new PlayerActiveEffect
+            {
+                PlayerUserId = player.Id,
+                InventoryId = 1,
+                RewardItemId = 1,
+                RewardItemTypeId = RewardItemTypeIds.XpBoost,
+                EffectValue = 1.5m,
+                ActivatedAt = DateTime.UtcNow,
+                ExpiresAt = DateTime.UtcNow.AddDays(1),
+                IsActive = true,
+            },
+            new PlayerActiveEffect
+            {
+                PlayerUserId = player.Id,
+                InventoryId = 2,
+                RewardItemId = 2,
+                RewardItemTypeId = RewardItemTypeIds.XpBoost,
+                EffectValue = 2m,
+                ActivatedAt = DateTime.UtcNow,
+                ExpiresAt = DateTime.UtcNow.AddDays(1),
+                IsActive = true,
+            });
+        await context.SaveChangesAsync();
+
+        var service = new PlayerEffectService(context);
+        var multiplier = await service.GetActiveXpMultiplierAsync(player.Id);
+
+        Assert.Equal(2m, multiplier);
+    }
+
+    [Fact]
+    public async Task TryConsumeStreakShieldAsync_WhenChargesAreEnough_ReturnsTrueAndDecrements()
+    {
+        var context = CreateContext();
+        var player = await SeedPlayerAsync(context);
+        var inventory = new PlayerInventory
+        {
+            PlayerUserId = player.Id,
+            RewardItemId = 1,
+            Quantity = 0,
+            IsEquipped = true,
+            AcquiredAt = DateTime.UtcNow,
+        };
+        context.PlayerInventories.Add(inventory);
+        await context.SaveChangesAsync();
+
+        context.PlayerActiveEffects.Add(new PlayerActiveEffect
+        {
+            PlayerUserId = player.Id,
+            InventoryId = inventory.Id,
+            RewardItemId = 1,
+            RewardItemTypeId = RewardItemTypeIds.StreakProtection,
+            EffectValue = 2m,
+            RemainingCharges = 2,
+            ActivatedAt = DateTime.UtcNow,
+            IsActive = true,
+            Inventory = inventory,
+        });
+        await context.SaveChangesAsync();
+
+        var service = new PlayerEffectService(context);
+        var consumed = await service.TryConsumeStreakShieldAsync(player.Id, 1);
+
+        Assert.True(consumed);
+        var effect = await context.PlayerActiveEffects.SingleAsync();
+        Assert.Equal(1, effect.RemainingCharges);
+    }
+
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static async Task<PlayerUser> SeedPlayerAsync(AppDbContext context)
+    {
+        var playerClass = new UserPlayerClass { Name = "Warrior", IsActive = true };
+        var person = new Person
+        {
+            Name = "Test",
+            LastName = "User",
+            Email = $"effect-{Guid.NewGuid()}@example.com",
+            IsActive = true,
+        };
+        var player = new PlayerUser
+        {
+            Person = person,
+            Class = playerClass,
+            UserName = $"effect-{Guid.NewGuid()}",
+            Password = "hash",
+            IsActive = true,
+            CreationDate = DateTime.UtcNow,
+        };
+
+        context.UserPlayerClasses.Add(playerClass);
+        context.Persons.Add(person);
+        context.PlayerUsers.Add(player);
+        await context.SaveChangesAsync();
+        return player;
+    }
+}
+
+public class HabitServiceRewardEffectsTests
+{
+    [Fact]
+    public async Task CompleteTaskAsync_AppliesActiveXpMultiplier()
+    {
+        var context = CreateContext();
+        var (player, task) = await SeedCompletionDataAsync(context);
+        context.PlayerActiveEffects.Add(new PlayerActiveEffect
+        {
+            PlayerUserId = player.Id,
+            InventoryId = 1,
+            RewardItemId = 1,
+            RewardItemTypeId = RewardItemTypeIds.XpBoost,
+            EffectValue = 2m,
+            ActivatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddDays(1),
+            IsActive = true,
+        });
+        await context.SaveChangesAsync();
+
+        var effectService = new PlayerEffectService(context);
+        var streakRepo = new Mock<IStreakLogRepository>();
+        streakRepo
+            .Setup(r => r.GetByPlayerAndDateAsync(It.IsAny<int>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync((StreakLog?)null);
+        streakRepo
+            .Setup(r => r.GetLastCompletionBeforeAsync(It.IsAny<int>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync((StreakLog?)null);
+        streakRepo
+            .Setup(r => r.HasProtectionInGapAsync(It.IsAny<int>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(false);
+
+        var taskRepo = new Mock<IHabitTaskRepository>();
+        taskRepo
+            .Setup(r => r.GetTrackedByIdForUserAsync(task.Id, player.Id))
+            .ReturnsAsync(task);
+        taskRepo
+            .Setup(r => r.CompleteTaskAsync(task, It.IsAny<StreakLog?>(), It.IsAny<IReadOnlyList<PlayerEvent>?>()))
+            .Returns(Task.CompletedTask);
+
+        var service = new HabitService(
+            new Mock<IHabitRepository>().Object,
+            taskRepo.Object,
+            new Mock<IRepetitionCriteriaRepository>().Object,
+            new Mock<ITimerCriteriaRepository>().Object,
+            streakRepo.Object,
+            CreateLevelProgressService(),
+            effectService,
+            context);
+
+        var response = await service.CompleteTaskAsync(
+            task.Id,
+            player.Id,
+            new CompleteHabitTaskRequestDto { CompletedAt = DateTime.UtcNow });
+
+        Assert.Equal(100, response.XpEarned);
+        Assert.Equal(100, task.EarnedXpSnapshot);
+    }
+
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static ILevelProgressService CreateLevelProgressService() =>
+        new LevelProgressService(
+            Options.Create(
+                new LevelingOptions
+                {
+                    Strategy = LevelingStrategy.EscalatingPercent,
+                    BaseXpPerLevel = 100,
+                    EscalationPercent = 20,
+                }));
+
+    private static async Task<(PlayerUser Player, HabitTask Task)> SeedCompletionDataAsync(AppDbContext context)
+    {
+        var playerClass = new UserPlayerClass { Name = "Warrior", IsActive = true };
+        var person = new Person
+        {
+            Name = "Test",
+            LastName = "User",
+            Email = $"complete-{Guid.NewGuid()}@example.com",
+            IsActive = true,
+        };
+        var player = new PlayerUser
+        {
+            Person = person,
+            Class = playerClass,
+            UserName = $"complete-{Guid.NewGuid()}",
+            Password = "hash",
+            ExperiencePoints = 0,
+            DaysStreak = 0,
+            IsActive = true,
+            CreationDate = DateTime.UtcNow,
+        };
+        var category = new HabitCategory { Name = "Health", IsActive = true };
+        var discipline = new HabitDiscipline { Category = category, Name = "Fitness", IsActive = true };
+        var habit = new Habit
+        {
+            Discipline = discipline,
+            User = player,
+            Title = "Run",
+            IsActive = true,
+        };
+        var task = new HabitTask
+        {
+            Habit = habit,
+            Title = "Morning run",
+            Difficulty = TaskDifficulty.HARD,
+            XpValue = 0,
+            Frequency = TaskFrequency.DAILY,
+            PeriodUnit = TaskPeriodUnit.DAYS,
+            StartDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)),
+            CompletionCriteria = TaskCompletionCriteria.REPETITIONS,
+            Evidence = TaskEvidence.PHOTO,
+            IsActive = true,
+            RepetitionCriteria = new RepetitionCriteria
+            {
+                NumRepetitionsObjective = 10,
+                TypeUnityMeasurementUnit = MeasurementUnit.REPS,
+                StatusRepetitionsCriteriaIsActive = true,
+            },
+        };
+
+        context.UserPlayerClasses.Add(playerClass);
+        context.Persons.Add(person);
+        context.PlayerUsers.Add(player);
+        context.HabitCategories.Add(category);
+        context.Disciplines.Add(discipline);
+        context.Habits.Add(habit);
+        context.HabitTasks.Add(task);
+        await context.SaveChangesAsync();
+
+        return (player, task);
+    }
+}

--- a/LevelUpLife-Backend.Tests/PlayerEffectServiceTests.cs
+++ b/LevelUpLife-Backend.Tests/PlayerEffectServiceTests.cs
@@ -192,6 +192,7 @@ public class HabitServiceRewardEffectsTests
 
         Assert.Equal(100, response.XpEarned);
         Assert.Equal(100, task.EarnedXpSnapshot);
+        Assert.Equal(100, player.Gold);
     }
 
     private static AppDbContext CreateContext()
@@ -230,6 +231,7 @@ public class HabitServiceRewardEffectsTests
             UserName = $"complete-{Guid.NewGuid()}",
             Password = "hash",
             ExperiencePoints = 0,
+            Gold = 0,
             DaysStreak = 0,
             IsActive = true,
             CreationDate = DateTime.UtcNow,

--- a/LevelUpLife-Backend.Tests/PlayerInventoryServiceTests.cs
+++ b/LevelUpLife-Backend.Tests/PlayerInventoryServiceTests.cs
@@ -1,0 +1,208 @@
+using LevelUpLifeBackend.Data;
+using LevelUpLifeBackend.Infrastructure;
+using LevelUpLifeBackend.Infrastructure.Configuration;
+using LevelUpLifeBackend.Infrastructure.Errors;
+using LevelUpLifeBackend.Models;
+using LevelUpLifeBackend.Repositories;
+using LevelUpLifeBackend.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace LevelUpLife_Backend.Tests;
+
+public class PlayerInventoryServiceTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static ILevelProgressService CreateLevelProgressService() =>
+        new LevelProgressService(
+            Options.Create(
+                new LevelingOptions
+                {
+                    Strategy = LevelingStrategy.EscalatingPercent,
+                    BaseXpPerLevel = 100,
+                    EscalationPercent = 20,
+                }));
+
+    private static async Task<(AppDbContext Context, PlayerUser Player, RewardItem Item)> SeedPurchaseDataAsync(
+        int gold = 300,
+        int cost = 50)
+    {
+        var context = CreateContext();
+        var playerClass = new UserPlayerClass { Name = "Warrior", IsActive = true };
+        var person = new Person
+        {
+            Name = "Test",
+            LastName = "User",
+            Email = $"test-{Guid.NewGuid()}@example.com",
+            IsActive = true,
+        };
+        var player = new PlayerUser
+        {
+            Person = person,
+            Class = playerClass,
+            UserName = $"user-{Guid.NewGuid()}",
+            Password = "hash",
+            Level = 1,
+            ExperiencePoints = 0,
+            Gold = gold,
+            IsActive = true,
+            CreationDate = DateTime.UtcNow,
+        };
+        var type = new RewardItemType
+        {
+            Id = RewardItemTypeIds.XpBoost,
+            Name = "Boost de XP",
+            IsActive = true,
+        };
+        var item = new RewardItem
+        {
+            TypeId = RewardItemTypeIds.XpBoost,
+            Type = type,
+            Name = "Boost XP x2 (1 día)",
+            CostGold = cost,
+            EffectValue = 2m,
+            DurationDays = 1,
+            IsActive = true,
+        };
+
+        context.UserPlayerClasses.Add(playerClass);
+        context.Persons.Add(person);
+        context.PlayerUsers.Add(player);
+        context.RewardItemTypes.Add(type);
+        context.RewardItems.Add(item);
+        await context.SaveChangesAsync();
+
+        return (context, player, item);
+    }
+
+    private static PlayerInventoryService CreateService(AppDbContext context) =>
+        new(
+            context,
+            new RewardItemRepository(context),
+            new PlayerActiveEffectRepository(context),
+            new PlayerEffectService(context),
+            CreateLevelProgressService());
+
+    [Fact]
+    public async Task PurchaseAsync_WhenGoldIsSufficient_DeductsGoldAndAddsInventory()
+    {
+        var (context, player, item) = await SeedPurchaseDataAsync();
+        var service = CreateService(context);
+
+        var result = await service.PurchaseAsync(player.Id, item.Id);
+
+        Assert.Equal(250, result.RemainingGold);
+        Assert.Equal(item.Id, result.Inventory.RewardItemId);
+        Assert.Equal(1, result.Inventory.Quantity);
+        Assert.False(result.Inventory.IsEquipped);
+
+        var updatedPlayer = await context.PlayerUsers.FindAsync(player.Id);
+        Assert.Equal(250, updatedPlayer!.Gold);
+    }
+
+    [Fact]
+    public async Task PurchaseAsync_WhenGoldIsInsufficient_ThrowsInventoryError()
+    {
+        var (context, player, item) = await SeedPurchaseDataAsync(gold: 10, cost: 50);
+        var service = CreateService(context);
+
+        var ex = await Assert.ThrowsAsync<InventoryError>(() => service.PurchaseAsync(player.Id, item.Id));
+
+        Assert.Equal(InventoryFailureKind.InsufficientGold, ex.Kind);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_XpBoost_CreatesActiveEffectAndSetsEquipped()
+    {
+        var (context, player, item) = await SeedPurchaseDataAsync();
+        var service = CreateService(context);
+        var purchase = await service.PurchaseAsync(player.Id, item.Id);
+
+        var result = await service.ActivateAsync(player.Id, purchase.Inventory.Id);
+
+        Assert.True(result.Inventory.IsEquipped);
+        Assert.Equal(0, result.Inventory.Quantity);
+        Assert.NotNull(result.ActiveEffect);
+        Assert.Equal(2m, result.ActiveEffect!.EffectValue);
+        Assert.NotNull(result.ActiveEffect.ExpiresAt);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_ReviveStreak_RestoresPreviousStreak()
+    {
+        var context = CreateContext();
+        var playerClass = new UserPlayerClass { Name = "Warrior", IsActive = true };
+        var person = new Person
+        {
+            Name = "Test",
+            LastName = "User",
+            Email = $"revive-{Guid.NewGuid()}@example.com",
+            IsActive = true,
+        };
+        var player = new PlayerUser
+        {
+            Person = person,
+            Class = playerClass,
+            UserName = $"revive-{Guid.NewGuid()}",
+            Password = "hash",
+            DaysStreak = 1,
+            Gold = 300,
+            IsActive = true,
+            CreationDate = DateTime.UtcNow,
+        };
+        var recoveryType = new RewardItemType
+        {
+            Id = RewardItemTypeIds.Recovery,
+            Name = "Recuperación",
+            IsActive = true,
+        };
+        var reviveItem = new RewardItem
+        {
+            TypeId = RewardItemTypeIds.Recovery,
+            Type = recoveryType,
+            Name = "Revivir Racha",
+            CostGold = 200,
+            IsActive = true,
+        };
+
+        context.UserPlayerClasses.Add(playerClass);
+        context.Persons.Add(person);
+        context.PlayerUsers.Add(player);
+        context.RewardItemTypes.Add(recoveryType);
+        context.RewardItems.Add(reviveItem);
+        context.PlayerEvents.Add(new PlayerEvent
+        {
+            PlayerUser = player,
+            EventType = PlayerEventType.STREAK_RESET,
+            PayloadJson = "{\"previousStreak\":12,\"newStreak\":1}",
+            CreatedAt = DateTime.UtcNow,
+        });
+        context.PlayerInventories.Add(new PlayerInventory
+        {
+            PlayerUser = player,
+            RewardItem = reviveItem,
+            Quantity = 1,
+            AcquiredAt = DateTime.UtcNow,
+        });
+        await context.SaveChangesAsync();
+
+        var inventory = await context.PlayerInventories.FirstAsync();
+        var service = CreateService(context);
+
+        var result = await service.ActivateAsync(player.Id, inventory.Id);
+
+        var updatedPlayer = await context.PlayerUsers.FindAsync(player.Id);
+        Assert.Equal(12, updatedPlayer!.DaysStreak);
+        Assert.Contains("12", result.RecoveryMessage);
+    }
+}

--- a/Migrations/202606200003_AddRewardEffectDurationAndActiveEffects.cs
+++ b/Migrations/202606200003_AddRewardEffectDurationAndActiveEffects.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LevelUpLife_Backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRewardEffectDurationAndActiveEffects : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                ALTER TABLE "LULM_REWARD_ITEM"
+                    ADD COLUMN IF NOT EXISTS "NUM_EFFECT_DURATION_DAYS" INTEGER NULL;
+
+                CREATE TABLE IF NOT EXISTS "LULT_PLAYER_ACTIVE_EFFECT" (
+                    "ID_PLAYER_ACTIVE_EFFECT"   SERIAL PRIMARY KEY,
+                    "ID_PLAYER_USER"            INTEGER NOT NULL
+                        REFERENCES "LULM_PLAYER_USER"("ID_PLAYER_USER") ON DELETE CASCADE,
+                    "ID_INVENTORY"              INTEGER NOT NULL
+                        REFERENCES "LULT_PLAYER_INVENTORY"("ID_INVENTORY") ON DELETE CASCADE,
+                    "ID_REWARD_ITEM"            INTEGER NOT NULL
+                        REFERENCES "LULM_REWARD_ITEM"("ID_REWARD_ITEM"),
+                    "ID_REWARD_ITEM_TYPE"       INTEGER NOT NULL
+                        REFERENCES "LULM_REWARD_ITEM_TYPE"("ID_REWARD_ITEM_TYPE"),
+                    "NUM_EFFECT_VALUE"            NUMERIC(10,2) NULL,
+                    "NUM_REMAINING_CHARGES"     INTEGER NULL,
+                    "FEC_ACTIVATED"             TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    "FEC_EXPIRES_AT"            TIMESTAMPTZ NULL,
+                    "STATUS_IS_ACTIVE"          BOOLEAN NOT NULL DEFAULT TRUE
+                );
+
+                CREATE INDEX IF NOT EXISTS "IX_LULT_PLAYER_ACTIVE_EFFECT_ID_PLAYER_USER"
+                    ON "LULT_PLAYER_ACTIVE_EFFECT"("ID_PLAYER_USER");
+
+                CREATE INDEX IF NOT EXISTS "IX_LULT_PLAYER_ACTIVE_EFFECT_ID_INVENTORY"
+                    ON "LULT_PLAYER_ACTIVE_EFFECT"("ID_INVENTORY");
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                DROP TABLE IF EXISTS "LULT_PLAYER_ACTIVE_EFFECT";
+
+                ALTER TABLE "LULM_REWARD_ITEM"
+                    DROP COLUMN IF EXISTS "NUM_EFFECT_DURATION_DAYS";
+                """);
+        }
+    }
+}

--- a/Models/PlayerActiveEffect.cs
+++ b/Models/PlayerActiveEffect.cs
@@ -1,0 +1,18 @@
+namespace LevelUpLifeBackend.Models;
+
+public class PlayerActiveEffect
+{
+    public int Id { get; set; }
+    public int PlayerUserId { get; set; }
+    public PlayerUser? PlayerUser { get; set; }
+    public int InventoryId { get; set; }
+    public PlayerInventory? Inventory { get; set; }
+    public int RewardItemId { get; set; }
+    public RewardItem? RewardItem { get; set; }
+    public int RewardItemTypeId { get; set; }
+    public decimal? EffectValue { get; set; }
+    public int? RemainingCharges { get; set; }
+    public DateTime ActivatedAt { get; set; }
+    public DateTime? ExpiresAt { get; set; }
+    public bool IsActive { get; set; }
+}

--- a/Models/PlayerEventType.cs
+++ b/Models/PlayerEventType.cs
@@ -6,4 +6,6 @@ public enum PlayerEventType
     STREAK_CONTINUED,
     STREAK_PROTECTION_USED,
     LEVEL_UP,
+    XP_PENALTY,
+    XP_PENALTY_REVERTED,
 }

--- a/Models/RewardItem.cs
+++ b/Models/RewardItem.cs
@@ -9,5 +9,6 @@ public class RewardItem
     public string? Description { get; set; }
     public int CostGold { get; set; }
     public decimal? EffectValue { get; set; }
+    public int? DurationDays { get; set; }
     public bool IsActive { get; set; }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -82,6 +82,8 @@ builder.Services.AddScoped<IRewardItemRepository, RewardItemRepository>();
 builder.Services.AddScoped<IRewardItemService, RewardItemService>();
 builder.Services.AddScoped<IPlayerInventoryRepository, PlayerInventoryRepository>();
 builder.Services.AddScoped<IPlayerInventoryService, PlayerInventoryService>();
+builder.Services.AddScoped<IPlayerActiveEffectRepository, PlayerActiveEffectRepository>();
+builder.Services.AddScoped<IPlayerEffectService, PlayerEffectService>();
 builder.Services.AddScoped<IStreakService, StreakService>();
 
 builder.Services.Configure<LevelUpLifeBackend.Infrastructure.Configuration.StreakProtectionOptions>(

--- a/Repositories/IPlayerActiveEffectRepository.cs
+++ b/Repositories/IPlayerActiveEffectRepository.cs
@@ -1,0 +1,11 @@
+using LevelUpLifeBackend.Models;
+
+namespace LevelUpLifeBackend.Repositories;
+
+public interface IPlayerActiveEffectRepository
+{
+    Task<IEnumerable<PlayerActiveEffect>> GetActiveByPlayerAsync(int playerUserId);
+    Task<PlayerActiveEffect?> GetActiveByInventoryIdAsync(int inventoryId);
+    Task<PlayerActiveEffect> AddAsync(PlayerActiveEffect effect);
+    Task UpdateAsync(PlayerActiveEffect effect);
+}

--- a/Repositories/IPlayerEventRepository.cs
+++ b/Repositories/IPlayerEventRepository.cs
@@ -5,4 +5,5 @@ namespace LevelUpLifeBackend.Repositories;
 public interface IPlayerEventRepository
 {
     Task AddAsync(PlayerEvent playerEvent);
+    Task<PlayerEvent?> GetLastByTypeAsync(int playerUserId, PlayerEventType eventType);
 }

--- a/Repositories/IPlayerInventoryRepository.cs
+++ b/Repositories/IPlayerInventoryRepository.cs
@@ -4,6 +4,7 @@ namespace LevelUpLifeBackend.Repositories;
 
 public interface IPlayerInventoryRepository
 {
+    Task<PlayerInventory?> GetByIdForPlayerAsync(int inventoryId, int playerUserId);
     Task<PlayerInventory?> GetByPlayerAndItemAsync(int playerUserId, int rewardItemId);
     Task<PlayerInventory> AddAsync(PlayerInventory entry);
     Task<PlayerInventory> UpdateAsync(PlayerInventory entry);

--- a/Repositories/IPlayerRepository.cs
+++ b/Repositories/IPlayerRepository.cs
@@ -4,6 +4,7 @@ namespace LevelUpLifeBackend.Repositories;
 
 public interface IPlayerRepository
 {
+    Task<PlayerUser?> GetActiveByIdAsync(int playerUserId);
     Task<PlayerUser?> GetActiveByIdWithRelationsAsync(int playerUserId);
     Task<PlayerUser?> GetByIdWithRelationsAsync(int playerUserId);
     Task<bool> UserNameExistsForAnotherUserAsync(string userName, int excludedPlayerUserId);

--- a/Repositories/IRewardItemRepository.cs
+++ b/Repositories/IRewardItemRepository.cs
@@ -6,4 +6,5 @@ namespace LevelUpLifeBackend.Repositories;
 public interface IRewardItemRepository
 {
     Task<IEnumerable<RewardItem>> GetFilteredAsync(RewardItemFilterRequestDto? filter);
+    Task<RewardItem?> GetActiveByIdAsync(int rewardItemId);
 }

--- a/Repositories/PlayerActiveEffectRepository.cs
+++ b/Repositories/PlayerActiveEffectRepository.cs
@@ -1,0 +1,47 @@
+using LevelUpLifeBackend.Data;
+using LevelUpLifeBackend.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace LevelUpLifeBackend.Repositories;
+
+public class PlayerActiveEffectRepository : IPlayerActiveEffectRepository
+{
+    private readonly AppDbContext _context;
+
+    public PlayerActiveEffectRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IEnumerable<PlayerActiveEffect>> GetActiveByPlayerAsync(int playerUserId)
+    {
+        return await _context.PlayerActiveEffects
+            .Include(e => e.RewardItem)
+                .ThenInclude(r => r!.Type)
+            .Include(e => e.Inventory)
+            .Where(e => e.PlayerUserId == playerUserId && e.IsActive)
+            .OrderByDescending(e => e.ActivatedAt)
+            .ToListAsync();
+    }
+
+    public async Task<PlayerActiveEffect?> GetActiveByInventoryIdAsync(int inventoryId)
+    {
+        return await _context.PlayerActiveEffects
+            .FirstOrDefaultAsync(e => e.InventoryId == inventoryId && e.IsActive);
+    }
+
+    public async Task<PlayerActiveEffect> AddAsync(PlayerActiveEffect effect)
+    {
+        await _context.PlayerActiveEffects.AddAsync(effect);
+        await _context.SaveChangesAsync();
+        await _context.Entry(effect).Reference(e => e.RewardItem).LoadAsync();
+        if (effect.RewardItem is not null)
+            await _context.Entry(effect.RewardItem).Reference(r => r.Type).LoadAsync();
+        return effect;
+    }
+
+    public async Task UpdateAsync(PlayerActiveEffect effect)
+    {
+        await _context.SaveChangesAsync();
+    }
+}

--- a/Repositories/PlayerEventRepository.cs
+++ b/Repositories/PlayerEventRepository.cs
@@ -1,5 +1,6 @@
 using LevelUpLifeBackend.Data;
 using LevelUpLifeBackend.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace LevelUpLifeBackend.Repositories;
 
@@ -16,5 +17,13 @@ public class PlayerEventRepository : IPlayerEventRepository
     {
         await _context.PlayerEvents.AddAsync(playerEvent);
         await _context.SaveChangesAsync();
+    }
+
+    public async Task<PlayerEvent?> GetLastByTypeAsync(int playerUserId, PlayerEventType eventType)
+    {
+        return await _context.PlayerEvents
+            .Where(e => e.PlayerUserId == playerUserId && e.EventType == eventType)
+            .OrderByDescending(e => e.CreatedAt)
+            .FirstOrDefaultAsync();
     }
 }

--- a/Repositories/PlayerInventoryRepository.cs
+++ b/Repositories/PlayerInventoryRepository.cs
@@ -13,6 +13,14 @@ public class PlayerInventoryRepository : IPlayerInventoryRepository
         _context = context;
     }
 
+    public async Task<PlayerInventory?> GetByIdForPlayerAsync(int inventoryId, int playerUserId)
+    {
+        return await _context.PlayerInventories
+            .Include(i => i.RewardItem)
+                .ThenInclude(r => r!.Type)
+            .FirstOrDefaultAsync(i => i.Id == inventoryId && i.PlayerUserId == playerUserId);
+    }
+
     public async Task<PlayerInventory?> GetByPlayerAndItemAsync(int playerUserId, int rewardItemId)
     {
         return await _context.PlayerInventories

--- a/Repositories/PlayerRepository.cs
+++ b/Repositories/PlayerRepository.cs
@@ -13,6 +13,12 @@ public class PlayerRepository : IPlayerRepository
         _context = context;
     }
 
+    public async Task<PlayerUser?> GetActiveByIdAsync(int playerUserId)
+    {
+        return await _context.PlayerUsers
+            .FirstOrDefaultAsync(u => u.Id == playerUserId && u.IsActive);
+    }
+
     public async Task<PlayerUser?> GetActiveByIdWithRelationsAsync(int playerUserId)
     {
         return await _context.PlayerUsers

--- a/Repositories/RewardItemRepository.cs
+++ b/Repositories/RewardItemRepository.cs
@@ -41,4 +41,11 @@ public class RewardItemRepository : IRewardItemRepository
 
         return await query.ToListAsync();
     }
+
+    public async Task<RewardItem?> GetActiveByIdAsync(int rewardItemId)
+    {
+        return await _context.RewardItems
+            .Include(ri => ri.Type)
+            .FirstOrDefaultAsync(ri => ri.Id == rewardItemId && ri.IsActive);
+    }
 }

--- a/Services/AuthService.cs
+++ b/Services/AuthService.cs
@@ -52,7 +52,8 @@ public class AuthService : IAuthService
             ExperiencePoints = 0,
             DaysStreak = 0,
             CreationDate = DateTime.UtcNow,
-            IsActive = true
+            IsActive = true,
+            Gold = 300,
         };
         await _authRepository.RegisterAsync(person, playerUser);
         return (true, "Usuario registrado exitosamente.");

--- a/Services/HabitService.cs
+++ b/Services/HabitService.cs
@@ -328,6 +328,7 @@ public class HabitService : IHabitService
         task.EarnedXpSnapshot = xpEarned;
         var previousLevel = _levelProgressService.CalculateLevel(player.ExperiencePoints);
         player.ExperiencePoints += xpEarned;
+        player.Gold += xpEarned;
         player.Level = _levelProgressService.CalculateLevel(player.ExperiencePoints);
 
         var streakResult = await ApplyStreakUpdateAsync(player, completionDate);

--- a/Services/HabitService.cs
+++ b/Services/HabitService.cs
@@ -17,6 +17,7 @@ public class HabitService : IHabitService
     private readonly ITimerCriteriaRepository _timerCriteriaRepository;
     private readonly IStreakLogRepository _streakLogRepository;
     private readonly ILevelProgressService _levelProgressService;
+    private readonly IPlayerEffectService _playerEffectService;
     private readonly AppDbContext _context;
 
     public HabitService(
@@ -26,6 +27,7 @@ public class HabitService : IHabitService
         ITimerCriteriaRepository timerCriteriaRepository,
         IStreakLogRepository streakLogRepository,
         ILevelProgressService levelProgressService,
+        IPlayerEffectService playerEffectService,
         AppDbContext context)
     {
         _habitRepository = habitRepository;
@@ -34,6 +36,7 @@ public class HabitService : IHabitService
         _timerCriteriaRepository = timerCriteriaRepository;
         _streakLogRepository = streakLogRepository;
         _levelProgressService = levelProgressService;
+        _playerEffectService = playerEffectService;
         _context = context;
     }
 
@@ -314,7 +317,11 @@ public class HabitService : IHabitService
         await EnsureCompletionRequirementsMetAsync(task, request.CompletedAt);
 
         var player = task.Habit.User;
-        var xpEarned = PlayerProgressMapper.CalculateXpEarned(task);
+        await _playerEffectService.DeactivateExpiredEffectsAsync(player.Id);
+
+        var baseXp = PlayerProgressMapper.CalculateXpEarned(task);
+        var xpMultiplier = await _playerEffectService.GetActiveXpMultiplierAsync(player.Id);
+        var xpEarned = (int)Math.Round(baseXp * xpMultiplier);
         var completionDate = DateOnly.FromDateTime(request.CompletedAt.ToUniversalTime());
 
         task.IsCompleted = true;
@@ -325,10 +332,9 @@ public class HabitService : IHabitService
 
         var streakResult = await ApplyStreakUpdateAsync(player, completionDate);
         var completionEvents = BuildCompletionEvents(
-            player.Id,
+            player,
             streakResult,
             previousLevel,
-            player.Level,
             completionDate
         );
 
@@ -342,23 +348,39 @@ public class HabitService : IHabitService
             player.DaysStreak);
     }
 
-    private static IReadOnlyList<PlayerEvent> BuildCompletionEvents(
-        int playerUserId,
+    private List<PlayerEvent> BuildCompletionEvents(
+        PlayerUser player,
         StreakUpdateResult streakResult,
         int previousLevel,
-        int newLevel,
         DateOnly completionDate)
     {
         var events = new List<PlayerEvent>();
         var createdAt = DateTime.UtcNow;
+        var newLevel = player.Level;
 
         if (streakResult.Updated && streakResult.WasReset)
         {
             events.Add(new PlayerEvent
             {
-                PlayerUserId = playerUserId,
+                PlayerUserId = player.Id,
                 EventType = PlayerEventType.STREAK_RESET,
-                PayloadJson = $"{{\"date\":\"{completionDate:yyyy-MM-dd}\",\"newStreak\":1}}",
+                PayloadJson =
+                    $"{{\"date\":\"{completionDate:yyyy-MM-dd}\",\"newStreak\":1,\"previousStreak\":{streakResult.PreviousStreakBeforeReset}}}",
+                CreatedAt = createdAt,
+            });
+
+            var xpBeforePenalty = player.ExperiencePoints;
+            var penaltyAmount = _playerEffectService.CalculateXpPenalty(xpBeforePenalty);
+            player.ExperiencePoints = Math.Max(0, xpBeforePenalty - penaltyAmount);
+            player.Level = _levelProgressService.CalculateLevel(player.ExperiencePoints);
+            newLevel = player.Level;
+
+            events.Add(new PlayerEvent
+            {
+                PlayerUserId = player.Id,
+                EventType = PlayerEventType.XP_PENALTY,
+                PayloadJson =
+                    $"{{\"amount\":{penaltyAmount},\"xpBefore\":{xpBeforePenalty},\"xpAfter\":{player.ExperiencePoints},\"reverted\":false}}",
                 CreatedAt = createdAt,
             });
         }
@@ -366,7 +388,7 @@ public class HabitService : IHabitService
         {
             events.Add(new PlayerEvent
             {
-                PlayerUserId = playerUserId,
+                PlayerUserId = player.Id,
                 EventType = PlayerEventType.STREAK_CONTINUED,
                 PayloadJson = $"{{\"date\":\"{completionDate:yyyy-MM-dd}\",\"streak\":{streakResult.NewStreakCount}}}",
                 CreatedAt = createdAt,
@@ -377,7 +399,7 @@ public class HabitService : IHabitService
         {
             events.Add(new PlayerEvent
             {
-                PlayerUserId = playerUserId,
+                PlayerUserId = player.Id,
                 EventType = PlayerEventType.LEVEL_UP,
                 PayloadJson = $"{{\"previousLevel\":{previousLevel},\"newLevel\":{newLevel}}}",
                 CreatedAt = createdAt,
@@ -392,7 +414,8 @@ public class HabitService : IHabitService
         StreakLog? Log,
         bool WasReset,
         bool ContinuedViaProtection,
-        int NewStreakCount
+        int NewStreakCount,
+        int PreviousStreakBeforeReset
     );
 
     private async Task EnsureCompletionRequirementsMetAsync(HabitTask task, DateTime completedAt)
@@ -452,7 +475,7 @@ public class HabitService : IHabitService
         var existingLog = await _streakLogRepository.GetByPlayerAndDateAsync(player.Id, completionDate);
         if (existingLog?.CompletionRecorded == true)
         {
-            return new StreakUpdateResult(false, null, false, false, player.DaysStreak);
+            return new StreakUpdateResult(false, null, false, false, player.DaysStreak, 0);
         }
 
         var lastCompletion = await _streakLogRepository.GetLastCompletionBeforeAsync(
@@ -472,11 +495,22 @@ public class HabitService : IHabitService
                 completionDate
             );
 
+        if (!gapHasProtection && lastCompletion is not null && dayGap > 1)
+        {
+            gapHasProtection = await _playerEffectService.TryConsumeStreakShieldAsync(
+                player.Id,
+                dayGap - 1);
+        }
+
         var (newStreak, wasReset) = StreakCalculator.ComputeStreakCount(
             lastCompletion,
             completionDate,
             gapHasProtection
         );
+
+        var previousStreakBeforeReset = wasReset
+            ? lastCompletion?.StreakCount ?? 0
+            : 0;
 
         player.DaysStreak = Math.Max(1, newStreak);
         var continuedViaProtection = gapHasProtection && !wasReset && dayGap > 1;
@@ -493,7 +527,13 @@ public class HabitService : IHabitService
             log = PlayerProgressMapper.ToStreakLog(player, completionDate);
         }
 
-        return new StreakUpdateResult(true, log, wasReset, continuedViaProtection, player.DaysStreak);
+        return new StreakUpdateResult(
+            true,
+            log,
+            wasReset,
+            continuedViaProtection,
+            player.DaysStreak,
+            previousStreakBeforeReset);
     }
 
     private static void ThrowCompletionRequirementsNotMet(string details)

--- a/Services/IPlayerInventoryService.cs
+++ b/Services/IPlayerInventoryService.cs
@@ -4,6 +4,7 @@ namespace LevelUpLifeBackend.Services;
 
 public interface IPlayerInventoryService
 {
-    Task<PlayerInventoryResponseDto> PurchaseAsync(int playerUserId, int rewardItemId);
-    Task<IEnumerable<PlayerInventoryResponseDto>> GetInventoryAsync(int playerUserId);
+    Task<PurchaseRewardItemResponseDto> PurchaseAsync(int playerUserId, int rewardItemId);
+    Task<ActivateInventoryItemResponseDto> ActivateAsync(int playerUserId, int inventoryId);
+    Task<PlayerInventoryListResponseDto> GetInventoryAsync(int playerUserId);
 }

--- a/Services/PlayerEffectService.cs
+++ b/Services/PlayerEffectService.cs
@@ -1,0 +1,106 @@
+using System.Text.Json;
+using LevelUpLifeBackend.Data;
+using LevelUpLifeBackend.Infrastructure;
+using LevelUpLifeBackend.Models;
+using LevelUpLifeBackend.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace LevelUpLifeBackend.Services;
+
+public interface IPlayerEffectService
+{
+    Task DeactivateExpiredEffectsAsync(int playerUserId);
+    Task<decimal> GetActiveXpMultiplierAsync(int playerUserId);
+    Task<bool> TryConsumeStreakShieldAsync(int playerUserId, int missedDays);
+    int CalculateXpPenalty(int currentExperiencePoints);
+}
+
+public class PlayerEffectService : IPlayerEffectService
+{
+    private readonly AppDbContext _context;
+
+    public PlayerEffectService(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task DeactivateExpiredEffectsAsync(int playerUserId)
+    {
+        var now = DateTime.UtcNow;
+        var effects = await _context.PlayerActiveEffects
+            .Include(e => e.Inventory)
+            .Where(e => e.PlayerUserId == playerUserId && e.IsActive)
+            .ToListAsync();
+
+        foreach (var effect in effects)
+        {
+            var expired = effect.ExpiresAt.HasValue && effect.ExpiresAt.Value <= now;
+            var depleted = effect.RewardItemTypeId == RewardItemTypeIds.StreakProtection
+                && effect.RemainingCharges is <= 0;
+
+            if (!expired && !depleted)
+                continue;
+
+            effect.IsActive = false;
+            if (effect.Inventory is not null)
+                effect.Inventory.IsEquipped = false;
+        }
+
+        if (effects.Count > 0)
+            await _context.SaveChangesAsync();
+    }
+
+    public async Task<decimal> GetActiveXpMultiplierAsync(int playerUserId)
+    {
+        await DeactivateExpiredEffectsAsync(playerUserId);
+
+        var multipliers = await _context.PlayerActiveEffects
+            .Where(e => e.PlayerUserId == playerUserId
+                && e.IsActive
+                && e.RewardItemTypeId == RewardItemTypeIds.XpBoost
+                && e.EffectValue.HasValue)
+            .Select(e => e.EffectValue!.Value)
+            .ToListAsync();
+
+        return multipliers.Count == 0 ? 1m : multipliers.Max();
+    }
+
+    public async Task<bool> TryConsumeStreakShieldAsync(int playerUserId, int missedDays)
+    {
+        if (missedDays <= 0)
+            return false;
+
+        await DeactivateExpiredEffectsAsync(playerUserId);
+
+        var shield = await _context.PlayerActiveEffects
+            .Include(e => e.Inventory)
+            .Where(e => e.PlayerUserId == playerUserId
+                && e.IsActive
+                && e.RewardItemTypeId == RewardItemTypeIds.StreakProtection
+                && e.RemainingCharges.HasValue
+                && e.RemainingCharges.Value > 0)
+            .OrderByDescending(e => e.RemainingCharges)
+            .FirstOrDefaultAsync();
+
+        if (shield is null || shield.RemainingCharges < missedDays)
+            return false;
+
+        shield.RemainingCharges -= missedDays;
+
+        if (shield.RemainingCharges <= 0)
+        {
+            shield.IsActive = false;
+            if (shield.Inventory is not null)
+                shield.Inventory.IsEquipped = false;
+        }
+
+        await _context.SaveChangesAsync();
+        return true;
+    }
+
+    public int CalculateXpPenalty(int currentExperiencePoints)
+    {
+        var percentPenalty = (int)Math.Round(currentExperiencePoints * 0.10m);
+        return Math.Max(25, percentPenalty);
+    }
+}

--- a/Services/PlayerInventoryService.cs
+++ b/Services/PlayerInventoryService.cs
@@ -1,68 +1,420 @@
+using System.Text.Json;
+using LevelUpLifeBackend.Data;
 using LevelUpLifeBackend.DTOs.Responses;
+using LevelUpLifeBackend.Infrastructure;
 using LevelUpLifeBackend.Infrastructure.Errors;
 using LevelUpLifeBackend.Models;
 using LevelUpLifeBackend.Repositories;
+using Microsoft.EntityFrameworkCore;
 
 namespace LevelUpLifeBackend.Services;
 
 public class PlayerInventoryService : IPlayerInventoryService
 {
-    private readonly IPlayerInventoryRepository _inventoryRepository;
+    private readonly AppDbContext _context;
     private readonly IRewardItemRepository _rewardItemRepository;
+    private readonly IPlayerActiveEffectRepository _activeEffectRepository;
+    private readonly IPlayerEffectService _playerEffectService;
+    private readonly ILevelProgressService _levelProgressService;
 
     public PlayerInventoryService(
-        IPlayerInventoryRepository inventoryRepository,
-        IRewardItemRepository rewardItemRepository)
+        AppDbContext context,
+        IRewardItemRepository rewardItemRepository,
+        IPlayerActiveEffectRepository activeEffectRepository,
+        IPlayerEffectService playerEffectService,
+        ILevelProgressService levelProgressService)
     {
-        _inventoryRepository = inventoryRepository;
+        _context = context;
         _rewardItemRepository = rewardItemRepository;
+        _activeEffectRepository = activeEffectRepository;
+        _playerEffectService = playerEffectService;
+        _levelProgressService = levelProgressService;
     }
 
-    public async Task<PlayerInventoryResponseDto> PurchaseAsync(int playerUserId, int rewardItemId)
+    public async Task<PurchaseRewardItemResponseDto> PurchaseAsync(int playerUserId, int rewardItemId)
     {
-        var items = await _rewardItemRepository.GetFilteredAsync(null);
-        var item = items.FirstOrDefault(i => i.Id == rewardItemId && i.IsActive);
-
+        var item = await _rewardItemRepository.GetActiveByIdAsync(rewardItemId);
         if (item is null)
+        {
             throw new NotFoundError(new ErrorResponse
             {
                 Code = 404,
                 Message = "Reward item not found.",
-                Details = $"No active reward item with ID {rewardItemId} exists."
+                Details = $"No active reward item with ID {rewardItemId} exists.",
             });
-
-        var existing = await _inventoryRepository.GetByPlayerAndItemAsync(playerUserId, rewardItemId);
-
-        PlayerInventory result;
-
-        if (existing is not null)
-        {
-            existing.Quantity += 1;
-            result = await _inventoryRepository.UpdateAsync(existing);
         }
-        else
+
+        await using var transaction = await _context.Database.BeginTransactionAsync();
+        try
         {
-            var entry = new PlayerInventory
+            var player = await _context.PlayerUsers
+                .FirstOrDefaultAsync(u => u.Id == playerUserId && u.IsActive);
+
+            if (player is null)
             {
-                PlayerUserId = playerUserId,
-                RewardItemId = rewardItemId,
-                Quantity = 1,
-                IsEquipped = false,
-                AcquiredAt = DateTime.UtcNow,
+                throw new NotFoundError(new ErrorResponse
+                {
+                    Code = 404,
+                    Message = "Player not found",
+                    Details = $"Player with id {playerUserId} was not found or is inactive.",
+                });
+            }
+
+            if (player.Gold < item.CostGold)
+            {
+                throw new InventoryError(
+                    new ErrorResponse
+                    {
+                        Code = 400,
+                        Message = "Insufficient gold.",
+                        Details = $"This item costs {item.CostGold} gold but you only have {player.Gold}.",
+                    },
+                    InventoryFailureKind.InsufficientGold);
+            }
+
+            player.Gold -= item.CostGold;
+
+            var existing = await _context.PlayerInventories
+                .Include(i => i.RewardItem)
+                    .ThenInclude(r => r!.Type)
+                .FirstOrDefaultAsync(i => i.PlayerUserId == playerUserId && i.RewardItemId == rewardItemId);
+
+            PlayerInventory result;
+            if (existing is not null)
+            {
+                existing.Quantity += 1;
+                result = existing;
+            }
+            else
+            {
+                result = new PlayerInventory
+                {
+                    PlayerUserId = playerUserId,
+                    RewardItemId = rewardItemId,
+                    Quantity = 1,
+                    IsEquipped = false,
+                    AcquiredAt = DateTime.UtcNow,
+                    RewardItem = item,
+                };
+                await _context.PlayerInventories.AddAsync(result);
+            }
+
+            await _context.SaveChangesAsync();
+            await transaction.CommitAsync();
+
+            if (result.RewardItem is null)
+            {
+                await _context.Entry(result).Reference(i => i.RewardItem).LoadAsync();
+                if (result.RewardItem is not null)
+                    await _context.Entry(result.RewardItem).Reference(r => r.Type).LoadAsync();
+            }
+
+            return new PurchaseRewardItemResponseDto
+            {
+                Inventory = ToInventoryDto(result),
+                RemainingGold = player.Gold,
             };
-            result = await _inventoryRepository.AddAsync(entry);
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+    }
+
+    public async Task<ActivateInventoryItemResponseDto> ActivateAsync(int playerUserId, int inventoryId)
+    {
+        await _playerEffectService.DeactivateExpiredEffectsAsync(playerUserId);
+
+        var entry = await _context.PlayerInventories
+            .Include(i => i.RewardItem)
+                .ThenInclude(r => r!.Type)
+            .FirstOrDefaultAsync(i => i.Id == inventoryId && i.PlayerUserId == playerUserId);
+
+        if (entry is null)
+        {
+            throw new NotFoundError(new ErrorResponse
+            {
+                Code = 404,
+                Message = "Inventory item not found.",
+                Details = $"No inventory entry with ID {inventoryId} exists for this player.",
+            });
         }
 
-        return ToDto(result);
+        if (entry.Quantity <= 0)
+        {
+            throw new InventoryError(
+                new ErrorResponse
+                {
+                    Code = 400,
+                    Message = "Item not activatable.",
+                    Details = "You do not have any units of this item left.",
+                },
+                InventoryFailureKind.ItemNotActivatable);
+        }
+
+        var item = entry.RewardItem;
+        if (item is null || !item.IsActive)
+        {
+            throw new NotFoundError(new ErrorResponse
+            {
+                Code = 404,
+                Message = "Reward item not found.",
+                Details = "The linked reward item is missing or inactive.",
+            });
+        }
+
+        var existingEffect = await _activeEffectRepository.GetActiveByInventoryIdAsync(inventoryId);
+        if (existingEffect is not null)
+        {
+            throw new InventoryError(
+                new ErrorResponse
+                {
+                    Code = 400,
+                    Message = "Effect already active.",
+                    Details = "This inventory item already has an active effect.",
+                },
+                InventoryFailureKind.EffectAlreadyActive);
+        }
+
+        await using var transaction = await _context.Database.BeginTransactionAsync();
+        try
+        {
+            var response = new ActivateInventoryItemResponseDto();
+
+            if (item.TypeId == RewardItemTypeIds.Recovery)
+            {
+                response.RecoveryMessage = await ApplyRecoveryEffectAsync(playerUserId, item);
+                entry.Quantity -= 1;
+                entry.IsEquipped = false;
+            }
+            else
+            {
+                var effect = CreateActiveEffect(playerUserId, entry, item);
+                await _context.PlayerActiveEffects.AddAsync(effect);
+                entry.Quantity -= 1;
+                entry.IsEquipped = true;
+                response.ActiveEffect = ToEffectDto(effect, item);
+            }
+
+            await _context.SaveChangesAsync();
+            await transaction.CommitAsync();
+
+            if (response.ActiveEffect is not null && response.ActiveEffect.RewardItemName == string.Empty)
+                response.ActiveEffect = ToEffectDto(
+                    await _context.PlayerActiveEffects
+                        .Include(e => e.RewardItem)
+                            .ThenInclude(r => r!.Type)
+                        .OrderByDescending(e => e.Id)
+                        .FirstAsync(e => e.InventoryId == inventoryId && e.IsActive),
+                    item);
+
+            response.Inventory = ToInventoryDto(entry);
+            return response;
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
     }
 
-    public async Task<IEnumerable<PlayerInventoryResponseDto>> GetInventoryAsync(int playerUserId)
+    public async Task<PlayerInventoryListResponseDto> GetInventoryAsync(int playerUserId)
     {
-        var entries = await _inventoryRepository.GetByPlayerAsync(playerUserId);
-        return entries.Select(ToDto);
+        await _playerEffectService.DeactivateExpiredEffectsAsync(playerUserId);
+
+        var entries = await _context.PlayerInventories
+            .AsNoTracking()
+            .Include(i => i.RewardItem)
+                .ThenInclude(r => r!.Type)
+            .Where(i => i.PlayerUserId == playerUserId)
+            .OrderBy(i => i.AcquiredAt)
+            .ToListAsync();
+
+        var activeEffects = await _context.PlayerActiveEffects
+            .AsNoTracking()
+            .Include(e => e.RewardItem)
+                .ThenInclude(r => r!.Type)
+            .Where(e => e.PlayerUserId == playerUserId && e.IsActive)
+            .OrderByDescending(e => e.ActivatedAt)
+            .ToListAsync();
+
+        return new PlayerInventoryListResponseDto
+        {
+            Items = entries.Select(ToInventoryDto),
+            ActiveEffects = activeEffects.Select(e => ToEffectDto(e, e.RewardItem!)),
+        };
     }
 
-    private static PlayerInventoryResponseDto ToDto(PlayerInventory entry) => new()
+    private static PlayerActiveEffect CreateActiveEffect(int playerUserId, PlayerInventory entry, RewardItem item)
+    {
+        var now = DateTime.UtcNow;
+        DateTime? expiresAt = null;
+        int? remainingCharges = null;
+
+        switch (item.TypeId)
+        {
+            case RewardItemTypeIds.StreakProtection:
+                remainingCharges = item.EffectValue.HasValue
+                    ? (int)item.EffectValue.Value
+                    : 1;
+                break;
+            case RewardItemTypeIds.XpBoost:
+            case RewardItemTypeIds.HabitExpansion:
+                if (item.DurationDays.HasValue && item.DurationDays.Value > 0)
+                    expiresAt = now.AddDays(item.DurationDays.Value);
+                break;
+        }
+
+        return new PlayerActiveEffect
+        {
+            PlayerUserId = playerUserId,
+            InventoryId = entry.Id,
+            RewardItemId = item.Id,
+            RewardItemTypeId = item.TypeId,
+            EffectValue = item.EffectValue,
+            RemainingCharges = remainingCharges,
+            ActivatedAt = now,
+            ExpiresAt = expiresAt,
+            IsActive = true,
+            RewardItem = item,
+        };
+    }
+
+    private async Task<string> ApplyRecoveryEffectAsync(int playerUserId, RewardItem item)
+    {
+        var player = await _context.PlayerUsers
+            .FirstOrDefaultAsync(u => u.Id == playerUserId && u.IsActive);
+
+        if (player is null)
+        {
+            throw new NotFoundError(new ErrorResponse
+            {
+                Code = 404,
+                Message = "Player not found",
+                Details = $"Player with id {playerUserId} was not found or is inactive.",
+            });
+        }
+
+        if (IsReviveStreakItem(item))
+            return await ReviveStreakAsync(player);
+
+        if (IsErasePenaltyItem(item))
+            return await EraseLastPenaltyAsync(player);
+
+        throw new InventoryError(
+            new ErrorResponse
+            {
+                Code = 400,
+                Message = "Item not activatable.",
+                Details = "This recovery item is not supported.",
+            },
+            InventoryFailureKind.ItemNotActivatable);
+    }
+
+    private async Task<string> ReviveStreakAsync(PlayerUser player)
+    {
+        var lastReset = await _context.PlayerEvents
+            .Where(e => e.PlayerUserId == player.Id && e.EventType == PlayerEventType.STREAK_RESET)
+            .OrderByDescending(e => e.CreatedAt)
+            .FirstOrDefaultAsync();
+
+        if (lastReset?.PayloadJson is null
+            || !TryReadIntProperty(lastReset.PayloadJson, "previousStreak", out var previousStreak)
+            || previousStreak <= 0)
+        {
+            throw new InventoryError(
+                new ErrorResponse
+                {
+                    Code = 400,
+                    Message = "No recovery target.",
+                    Details = "There is no recent streak loss to restore.",
+                },
+                InventoryFailureKind.NoRecoveryTarget);
+        }
+
+        player.DaysStreak = previousStreak;
+        return $"Streak restored to {previousStreak} days.";
+    }
+
+    private async Task<string> EraseLastPenaltyAsync(PlayerUser player)
+    {
+        var lastPenalty = await _context.PlayerEvents
+            .Where(e => e.PlayerUserId == player.Id && e.EventType == PlayerEventType.XP_PENALTY)
+            .OrderByDescending(e => e.CreatedAt)
+            .FirstOrDefaultAsync();
+
+        if (lastPenalty?.PayloadJson is null
+            || !TryReadIntProperty(lastPenalty.PayloadJson, "amount", out var amount)
+            || amount <= 0)
+        {
+            throw new InventoryError(
+                new ErrorResponse
+                {
+                    Code = 400,
+                    Message = "No recovery target.",
+                    Details = "There is no XP penalty available to erase.",
+                },
+                InventoryFailureKind.NoRecoveryTarget);
+        }
+
+        var alreadyReverted = await _context.PlayerEvents.AnyAsync(e =>
+            e.PlayerUserId == player.Id
+            && e.EventType == PlayerEventType.XP_PENALTY_REVERTED
+            && e.CreatedAt > lastPenalty.CreatedAt);
+
+        if (alreadyReverted)
+        {
+            throw new InventoryError(
+                new ErrorResponse
+                {
+                    Code = 400,
+                    Message = "No recovery target.",
+                    Details = "The last XP penalty has already been erased.",
+                },
+                InventoryFailureKind.NoRecoveryTarget);
+        }
+
+        player.ExperiencePoints += amount;
+        player.Level = _levelProgressService.CalculateLevel(player.ExperiencePoints);
+
+        await _context.PlayerEvents.AddAsync(new PlayerEvent
+        {
+            PlayerUserId = player.Id,
+            EventType = PlayerEventType.XP_PENALTY_REVERTED,
+            PayloadJson = $"{{\"amount\":{amount},\"xpAfter\":{player.ExperiencePoints}}}",
+            CreatedAt = DateTime.UtcNow,
+        });
+
+        return $"Restored {amount} XP.";
+    }
+
+    private static bool IsReviveStreakItem(RewardItem item) =>
+        item.Name.Contains("Revivir", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsErasePenaltyItem(RewardItem item) =>
+        item.Name.Contains("Borrador", StringComparison.OrdinalIgnoreCase);
+
+    private static bool TryReadIntProperty(string json, string propertyName, out int value)
+    {
+        value = 0;
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            if (document.RootElement.TryGetProperty(propertyName, out var property)
+                && property.TryGetInt32(out value))
+            {
+                return true;
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return false;
+    }
+
+    private static PlayerInventoryResponseDto ToInventoryDto(PlayerInventory entry) => new()
     {
         Id = entry.Id,
         PlayerUserId = entry.PlayerUserId,
@@ -72,8 +424,24 @@ public class PlayerInventoryService : IPlayerInventoryService
         RewardItemTypeName = entry.RewardItem?.Type?.Name ?? string.Empty,
         CostGold = entry.RewardItem?.CostGold ?? 0,
         EffectValue = entry.RewardItem?.EffectValue,
+        DurationDays = entry.RewardItem?.DurationDays,
         Quantity = entry.Quantity,
         IsEquipped = entry.IsEquipped,
         AcquiredAt = entry.AcquiredAt,
+    };
+
+    private static PlayerActiveEffectResponseDto ToEffectDto(PlayerActiveEffect effect, RewardItem item) => new()
+    {
+        Id = effect.Id,
+        InventoryId = effect.InventoryId,
+        RewardItemId = effect.RewardItemId,
+        RewardItemName = item.Name,
+        RewardItemTypeId = effect.RewardItemTypeId,
+        RewardItemTypeName = item.Type?.Name ?? string.Empty,
+        EffectValue = effect.EffectValue,
+        RemainingCharges = effect.RemainingCharges,
+        ActivatedAt = effect.ActivatedAt,
+        ExpiresAt = effect.ExpiresAt,
+        IsActive = effect.IsActive,
     };
 }

--- a/Services/RewardItemService.cs
+++ b/Services/RewardItemService.cs
@@ -29,6 +29,7 @@ public class RewardItemService : IRewardItemService
                 Description = ri.Description,
                 CostGold = ri.CostGold,
                 EffectValue = ri.EffectValue,
+                DurationDays = ri.DurationDays,
                 IsActive = ri.IsActive,
             });
         }


### PR DESCRIPTION
# Gold Economy, Shop, Inventory, and Item Effects

Documentation for the functionality implemented on the `rewards_and_effects` branch. Covers database changes, endpoints, business rules, and frontend integration.

---

## Executive Summary

| Area | What was implemented |
|------|----------------------|
| Gold | 300 on registration; earn gold when completing missions (1 XP = 1 gold); spend gold on purchases |
| Shop | Item catalog with price, type, effect, and duration |
| Inventory | Purchase, activation, and player item listing |
| Effects | Active effects table; automatic application on streak and XP |
| Recovery | Revive streak and erase XP penalty |

---

## Database

### Existing tables (no major structural changes)

| Table | Purpose |
|-------|---------|
| `LULM_REWARD_ITEM_TYPE` | Type catalog (1–4) |
| `LULM_REWARD_ITEM` | Shop item catalog |
| `LULT_PLAYER_INVENTORY` | Player backpack / inventory |
| `LULM_PLAYER_USER` | `NUM_PLAYER_USER_GOLD` column for player gold |

### New migration: `202606200003_AddRewardEffectDurationAndActiveEffects`

**Apply with:**

```bash
dotnet ef database update
```

#### 1. New catalog column

```sql
ALTER TABLE "LULM_REWARD_ITEM"
    ADD COLUMN IF NOT EXISTS "NUM_EFFECT_DURATION_DAYS" INTEGER NULL;
```

| Column | Type | Description |
|--------|------|-------------|
| `NUM_EFFECT_DURATION_DAYS` | `INTEGER NULL` | Duration in days for temporary effects (boosts, slots). `NULL` = permanent or no time-based duration |

#### 2. New table: active effects

```sql
CREATE TABLE "LULT_PLAYER_ACTIVE_EFFECT" ( ... );
```

| Column | Type | Description |
|--------|------|-------------|
| `ID_PLAYER_ACTIVE_EFFECT` | `SERIAL PK` | Active effect identifier |
| `ID_PLAYER_USER` | `INTEGER FK` | Player |
| `ID_INVENTORY` | `INTEGER FK` | Inventory item that triggered the effect |
| `ID_REWARD_ITEM` | `INTEGER FK` | Catalog item |
| `ID_REWARD_ITEM_TYPE` | `INTEGER FK` | Type (1–4) |
| `NUM_EFFECT_VALUE` | `NUMERIC(10,2)` | Multiplier, charges, slots, etc. |
| `NUM_REMAINING_CHARGES` | `INTEGER NULL` | Streak shields only (type 1) |
| `FEC_ACTIVATED` | `TIMESTAMPTZ` | Effect start time |
| `FEC_EXPIRES_AT` | `TIMESTAMPTZ NULL` | Effect end time (`NULL` = permanent) |
| `STATUS_IS_ACTIVE` | `BOOLEAN` | Whether the effect is still active |

**Indexes:** on `ID_PLAYER_USER` and `ID_INVENTORY`.

### Item catalog (data in DB, not in migration)

The catalog of 10 items and 4 types is loaded manually in the database. Reference:

| typeId | Type | Examples |
|--------|------|----------|
| 1 | Streak protection | Streak Shield, Double Shield, Weekly Shield |
| 2 | XP boost | Boost x1.5 (1 day), x2 (1 day), x2 (3 days) |
| 3 | Habit expansion | Temporary slot (7 days), Permanent slot |
| 4 | Recovery | Revive Streak, Penalty Eraser |

**Field mapping by type:**

| Type | `NUM_REWARD_ITEM_EFFECT_VALUE` | `NUM_EFFECT_DURATION_DAYS` |
|------|----------------------------------|----------------------------|
| 1 Shield | Protected days/charges (1, 2, 7) | `NULL` |
| 2 XP boost | Multiplier (1.5, 2) | 1 or 3 |
| 3 Extra slot | +1 slot | 7 or `NULL` |
| 4 Recovery | `NULL` | `NULL` |

---

## Gold Economy

### Rules

| Event | Gold |
|-------|------|
| User registration | +300 (`AuthService`) |
| Complete mission | +XP earned (1:1 ratio) |
| Purchase item | -`costGold` |
| Streak loss penalty | Does not affect gold (XP only) |

### Where to read gold

- `GET /api/player/profile` → `gold` field

### Frontend note

`PATCH /api/habit-tasks/{id}/complete` does **not** return `gold`. After completing a mission:

- `gold += response.xpEarned`, or
- refresh profile with `GET /api/player/profile`

---

## Endpoints

### Authentication

Shop/inventory endpoints accept:

- Standard JWT, or
- Header `X-User-Id: {playerUserId}` (useful in development)

---

### `GET /api/RewardItem`

Lists the shop catalog.

**Body (optional):** filters by type, name, price, etc.

**200 response:** array of items

```json
{
  "id": 4,
  "typeId": 2,
  "typeName": "XP Boost",
  "name": "Boost XP x1.5 (1 day)",
  "description": "Multiplies all task XP by 1.5 for 24 hours",
  "costGold": 60,
  "effectValue": 1.5,
  "durationDays": 1,
  "isActive": true
}
```

---

### `POST /api/RewardItem/{itemId}/purchase`

Purchases an item. Deducts gold in a transaction and adds to inventory.

**201 response:**

```json
{
  "inventory": {
    "id": 12,
    "playerUserId": 1,
    "rewardItemId": 4,
    "rewardItemName": "Boost XP x1.5 (1 day)",
    "rewardItemTypeId": 2,
    "rewardItemTypeName": "XP Boost",
    "costGold": 60,
    "effectValue": 1.5,
    "durationDays": 1,
    "quantity": 1,
    "isEquipped": false,
    "acquiredAt": "2026-06-20T12:00:00Z"
  },
  "remainingGold": 240
}
```

**Errors:**

| Code | Case |
|------|------|
| 400 | Insufficient gold (`Insufficient gold.`) |
| 404 | Item not found or inactive |
| 401 | Not authenticated |

---

### `GET /api/RewardItem/inventory`

Player inventory + active effects.

**200 response:**

```json
{
  "items": [
    {
      "id": 12,
      "rewardItemId": 4,
      "rewardItemName": "Boost XP x1.5 (1 day)",
      "rewardItemTypeId": 2,
      "quantity": 2,
      "isEquipped": false,
      "effectValue": 1.5,
      "durationDays": 1,
      "acquiredAt": "..."
    }
  ],
  "activeEffects": [
    {
      "id": 5,
      "inventoryId": 10,
      "rewardItemId": 5,
      "rewardItemName": "Boost XP x2 (1 day)",
      "rewardItemTypeId": 2,
      "rewardItemTypeName": "XP Boost",
      "effectValue": 2,
      "remainingCharges": null,
      "activatedAt": "...",
      "expiresAt": "...",
      "isActive": true
    }
  ]
}
```

> **Important change:** previously returned a flat array; now returns `{ items, activeEffects }`.

---

### `POST /api/RewardItem/inventory/{inventoryId}/activate`

Activates an inventory item (`isEquipped: false → true` for types 1–3). The frontend must **not** write `isEquipped` directly.

**Behavior by type:**

| typeId | On activate | `isEquipped` | `quantity` |
|--------|-------------|--------------|------------|
| 1 Streak shield | Creates effect with charges | `true` | -1 |
| 2 XP boost | Creates temporary effect | `true` | -1 |
| 3 Extra slot | Creates effect (informational) | `true` | -1 |
| 4 Recovery | Instant effect | `false` | -1 |

**200 response (temporary effect):**

```json
{
  "inventory": {
    "id": 12,
    "quantity": 0,
    "isEquipped": true,
    ...
  },
  "activeEffect": {
    "rewardItemTypeId": 2,
    "effectValue": 2,
    "expiresAt": "2026-06-21T12:00:00Z",
    "remainingCharges": null,
    "isActive": true
  },
  "recoveryMessage": null
}
```

**200 response (instant recovery):**

```json
{
  "inventory": { "quantity": 0, "isEquipped": false, ... },
  "activeEffect": null,
  "recoveryMessage": "Streak restored to 12 days."
}
```

**400 errors:**

- No units left (`quantity = 0`)
- Effect already active for that inventory row
- Recovery with no valid target (no lost streak / no penalty to erase)

---

### `GET /api/player/profile`

Includes the player's current gold.

```json
{
  "gold": 340,
  "daysStreak": 5,
  "totalExperiencePoints": 1200,
  ...
}
```

---

### `PATCH /api/habit-tasks/{id}/complete`

No changes to the response contract. Effects applied internally:

- Adds XP (with active boost multiplier)
- Adds gold (`gold += xpEarned`)
- Updates streak (with shield if applicable)
- XP penalty on streak loss (-10%, minimum 25)

---

## Effects and Duration

### Two layers

1. **Catalog** (`LULM_REWARD_ITEM`): defines what the item does (`effectValue`, `durationDays`).
2. **Active effect** (`LULT_PLAYER_ACTIVE_EFFECT`): created on activation; stores runtime state.

### How duration is calculated on activation

| Type | Duration | Mechanism |
|------|----------|-----------|
| 1 Shield | By charges | `remainingCharges = effectValue`; decreases when days are skipped |
| 2 XP boost | By time | `expiresAt = now + durationDays` |
| 3 Extra slot | By time or permanent | `expiresAt` if days set; otherwise `null` |
| 4 Recovery | Instant | Does not create an active effect |

### Runtime application

| Type | When | Logic |
|------|------|-------|
| 1 Shield | Complete mission with day gap | Protects streak; consumes charges |
| 2 XP boost | Complete mission | `xp = baseXp × max(active multipliers)` |
| 3 Extra slot | UI only | Visible in `activeEffects`; does not limit habits |
| 4 Revive streak | On activate | Restores `previousStreak` from last `STREAK_RESET` |
| 4 Penalty eraser | On activate | Restores XP from last penalty |

### Streak loss penalty

- On streak reset: -10% of current XP (minimum 25)
- `XP_PENALTY` event in `LULH_PLAYER_EVENT`
- `STREAK_RESET` payload includes `previousStreak` for Revive Streak

### Automatic expiration

Runs on activate, mission complete, and inventory fetch.

Deactivates the effect and sets `isEquipped = false` when:

- `expiresAt < now`, or
- `remainingCharges <= 0` (shields)

---

## Full Flow

```
Register → 300 gold
    ↓
Complete missions → gold += xpEarned
    ↓
GET /api/RewardItem → view shop
    ↓
POST /api/RewardItem/{id}/purchase → spend gold, add to inventory
    ↓
GET /api/RewardItem/inventory → view backpack + active effects
    ↓
POST /api/RewardItem/inventory/{id}/activate → isEquipped true, apply effect
    ↓
Complete mission → boost/shield effects apply automatically
    ↓
Effect expires or depletes → isEquipped false automatically
```

---

## Main Backend Files

| File | Responsibility |
|------|----------------|
| `Services/AuthService.cs` | Initial 300 gold |
| `Services/HabitService.cs` | Gold per mission, XP boost, shield, penalty |
| `Services/PlayerInventoryService.cs` | Purchase, activation, inventory |
| `Services/PlayerEffectService.cs` | XP multiplier, shield, expiration |
| `Controllers/RewardItemController.cs` | Shop/inventory endpoints |
| `Models/PlayerActiveEffect.cs` | Active effect model |
| `Migrations/202606200003_AddRewardEffectDurationAndActiveEffects.cs` | DB schema |

---

## Common Database Errors

| Error | Cause | Fix |
|-------|-------|-----|
| `column NUM_EFFECT_DURATION_DAYS does not exist` | Migration not applied | `dotnet ef database update` |
| `relation LULT_PLAYER_ACTIVE_EFFECT does not exist` | Migration not applied | `dotnet ef database update` |

---

## Out of Scope (this version)

- Automatic catalog seed in migrations
- Manual unequip endpoint (`true → false`)
- `goldEarned` in mission complete response
- Active habit slot limit (extra slot is informational only)
- Earning gold from sources other than missions

---

## Frontend Integration Checklist

- [ ] Display `gold` in profile/header
- [ ] Shop with prices and balance validation before purchase
- [ ] Purchase: update gold with `remainingGold`
- [ ] Inventory: consume `{ items, activeEffects }` (not a flat array)
- [ ] Activate button → `POST .../inventory/{id}/activate` (do not write `isEquipped` directly)
- [ ] After mission complete: `gold += xpEarned`
- [ ] Active effects panel with `expiresAt` and `remainingCharges`
- [ ] Handle 400 errors (insufficient gold, no recovery target)
